### PR TITLE
chore: Docker 설정 및 Github Action으로 자동배포 완료

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -13,18 +13,23 @@ jobs:
         run: |
           docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{ secrets.DOCKER_PASSWORD }}
           echo "---- express-server ----"
+          echo ${{secrets.MONGO_URL}} > ./server/.env
           docker build -t express-server ./server
           docker tag express-server ${{secrets.DOCKER_USERNAME}}/express-server
           docker push ${{secrets.DOCKER_USERNAME}}/express-server
           echo "---- fastapi-server ----"
           docker build -t fastapi-server ./python
           docker tag fastapi-server ${{secrets.DOCKER_USERNAME}}/fastapi-server
-          docker push ${{secrets.DOCKER_USERNAME}}/fastapi-serve
+          docker push ${{secrets.DOCKER_USERNAME}}/fastapi-server
       - name: Deploy
-        uses: cross-the-world/ssh-pipeline@v1.2.0
+        uses: appleboy/ssh-action@master
         with:
           host: ${{secrets.NCLOUD_HOST}}
-          user: root
-          pass: ${{secrets.NCLOUD_PASSWORD}}
+          username: ${{secrets.NCLOUD_USERNAME}}
+          password: ${{secrets.NCLOUD_PASSWORD}}
+          port: ${{secrets.NCLOUD_PORT}}
           script: |
-            echo "---- ssh complete! ----"
+            docker pull ${{secrets.DOCKER_USERNAME}}/express-server
+            docker tag ${{secrets.DOCKER_USERNAME}}/express-server express-server
+            docker stop express-server
+            docker run -d --rm --name express-server -p 3000:3000 express-server

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -13,7 +13,9 @@ jobs:
         run: |
           docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{ secrets.DOCKER_PASSWORD }}
           echo "---- express-server ----"
-          echo ${{secrets.MONGO_URL}} > ./server/.env
+          echo "${{secrets.MONGO_URL}}" >> ./server/.env
+          echo "${{secrets.FASTAPI_ENDPOINT}}" >> ./server/.env
+          cat ./server/.env
           docker build -t express-server ./server
           docker tag express-server ${{secrets.DOCKER_USERNAME}}/express-server
           docker push ${{secrets.DOCKER_USERNAME}}/express-server
@@ -30,6 +32,10 @@ jobs:
           port: ${{secrets.NCLOUD_PORT}}
           script: |
             docker pull ${{secrets.DOCKER_USERNAME}}/express-server
+            docker pull ${{secrets.DOCKER_USERNAME}}/fastapi-server
             docker tag ${{secrets.DOCKER_USERNAME}}/express-server express-server
+            docker tag ${{secrets.DOCKER_USERNAME}}/fastapi-server fastapi-server
             docker stop express-server
+            docker stop fastapi-server
             docker run -d --rm --name express-server -p 3000:3000 express-server
+            docker run -d --rm --name fastapi-server -p 8000:8000 fastapi-server

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,9 +1,9 @@
 name: Deploy
 on:
   push:
-    branches: ["main"]
+    branches: ["feat/docker"]
   pull_request:
-    branches: ["main"]
+    branches: ["feat/docker"]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build the express Docker image & push to dockerhub
+        run: |
+          docker login -u ${{secrets.DOCKER_USERNAME}} -p ${{ secrets.DOCKER_PASSWORD }}
+          echo "---- express-server ----"
+          docker build -t express-server ./server
+          docker tag express-server ${{secrets.DOCKER_USERNAME}}/express-server
+          docker push ${{secrets.DOCKER_USERNAME}}/express-server
+          echo "---- fastapi-server ----"
+          docker build -t fastapi-server ./python
+          docker tag fastapi-server ${{secrets.DOCKER_USERNAME}}/fastapi-server
+          docker push ${{secrets.DOCKER_USERNAME}}/fastapi-serve
+      - name: Deploy
+        uses: cross-the-world/ssh-pipeline@v1.2.0
+        with:
+          host: ${{secrets.NCLOUD_HOST}}
+          user: root
+          pass: ${{secrets.NCLOUD_PASSWORD}}
+          script: |
+            echo "---- ssh complete! ----"

--- a/mac-python-init.sh
+++ b/mac-python-init.sh
@@ -1,0 +1,4 @@
+cd python
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9
+ENV DEBIAN_FRONTEND noninteractive 
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN mkdir /usr/app
+WORKDIR /usr/app
+ADD . /usr/app
+RUN pip install -r requirements.txt
+ENTRYPOINT uvicorn main:app --reload --host=0.0.0.0 --port=8000

--- a/python/main.py
+++ b/python/main.py
@@ -5,5 +5,5 @@ from fastapi import FastAPI
 app = FastAPI()
 
 @app.get("/")
-async def root():
+def root():
     return {"message": "Hello World"}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu
+ENV DEBIAN_FRONTEND noninteractive 
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get -y install npm
+RUN mkdir /usr/app
+WORKDIR /usr/app
+ADD . /usr/app
+RUN npm i
+ENTRYPOINT npm run server

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,7 @@ const app = express();
 const port = 3000;
 
 const mongoURI = process.env.mongo_url;
-await mongoose.connect(mongoURI);
+mongoose.connect(mongoURI);
 const db = mongoose.connection;
 db.once("open", () => console.log("DB successfully connected"));
 db.on("error", (err) => console.log("DB connection failed : ", err));
@@ -47,7 +47,7 @@ app.get("/testGet", async (req, res) => {
   // Promise 객체를 정말로 상속하는가?
   // 아니면 Promise 프로토콜같은 게 있어서 그걸 따르기만 하면 await를 넣을 수 있는것일까?
   console.log(allData);
-  res.json({ result: "test" });
+  res.json(allData);
 });
 
 // FastAPI 연결 확인 test

--- a/server/index.js
+++ b/server/index.js
@@ -52,7 +52,8 @@ app.get("/testGet", async (req, res) => {
 
 // FastAPI 연결 확인 test
 app.get("/pytest", (req, res) => {
-  axios.get("http://127.0.0.1:8000/").then(() => {
+  const fastapiEndpoint = process.env.fastapi_endpoint;
+  axios.get(fastapiEndpoint).then(() => {
     res.send("pytest");
   });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ dotenv.config();
 const app = express();
 const port = 3000;
 
-const mongoURI = process.env.mongo_url;
+const mongoURI = process.env.MONGO_URL;
 mongoose.connect(mongoURI);
 const db = mongoose.connection;
 db.once("open", () => console.log("DB successfully connected"));
@@ -52,7 +52,7 @@ app.get("/testGet", async (req, res) => {
 
 // FastAPI 연결 확인 test
 app.get("/pytest", (req, res) => {
-  const fastapiEndpoint = process.env.fastapi_endpoint;
+  const fastapiEndpoint = process.env.FASTAPI_ENDPOINT;
   axios.get(fastapiEndpoint).then(() => {
     res.send("pytest");
   });


### PR DESCRIPTION
(dev 브랜치에 merge가 안 된 상태이므로 제가 대신 PR을 날립니다.)
## 현재 진행 상황
- Express 서버, FastAPI 서버에 도커 설정 파일을 생성했습니다.
- 깃허브에 push, merge할 시 레포지토리에서 도커 이미지를 생성하고, 이를 가져와서 배포 서버에서 배포하는 github action을 작성했습니다.
## 트러블슈팅
### 배포에서 사용되는 환경변수 문제
현재는 MongoDB Atlas 서버에 접속하여 개발을 하고 있는데, MongoDB 서버 주소 정보는 다른 사람에게 공개되어서는 안 되는 정보이므로 dotenv 라이브러리와 .env 파일을 이용해 관리를 하고 있습니다. 하지만 .env 파일은 깃허브 레포지토리에는 존재하지 않으므로, 환경변수가 설정되지 않은 상태에서 배포 서버에서 DB 연결 시도시 서버가 오류가 나는 문제가 있었습니다.
```sh
echo "${{secrets.MONGO_URL}}" >> ./server/.env
echo "${{secrets.FASTAPI_ENDPOINT}}" >> ./server/.env
```
배포 환경변수들을 깃허브 내부 secret으로 관리하고, (깃허브 액션을 실행하는 가상 환경에서) 도커 이미지를 생성하기 전 `./server/.env` 경로에 값을 주입하여 새 텍스트 파일을 생성합니다. 이 값들은 express 서버가 실행되면 dotenv로 express 서버 프로세스의 환경변수로 설정됩니다.