### PR TITLE
chore: vite dev server 자체 라우팅 플러그인 추가

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -31,6 +31,7 @@
     "no-undef": 0,
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
-    "react/no-unknown-property": "off"
+    "react/no-unknown-property": "off",
+    "prettier/prettier": ["error", { "endOfLine": "auto" }]
   }
 }

--- a/client/vite-devRouter.js
+++ b/client/vite-devRouter.js
@@ -1,0 +1,30 @@
+export function devRouter(rawRouteList) {
+  // 문자열로 된 route list를 정규표현식으로 변환하고, 정규표현식이 아닌 것들을 제거합니다.
+  const routeList = rawRouteList.map( ([route, html])=>{
+    if(typeof route === "string") {
+      route = new RegExp(`^${route.replace(/\*/g, ".*").replace(/\?/g, ".")}/?$`);
+    }
+    return [route, html];
+  } ).filter( ([route])=>(route instanceof RegExp) );
+
+  // 요청한 패스가 설정된 라우팅 경로에 맞는지 확인합니다.
+  function foundRoute(path) {
+    for(let [route, html] of routeList) {
+      if(route.test(path)) return html;
+    }
+    return null;
+  }
+
+  return {
+    name: "route-server",
+    configureServer(server) {
+      server.middlewares.use( (req, res, next)=>{
+        const htmlPath = foundRoute(req.originalUrl);
+        if(htmlPath === null) return next();
+        req.url = htmlPath;
+        req.originalUrl = htmlPath;
+        next();
+      } );
+    }
+  }
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -2,10 +2,18 @@ import * as path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import eslint from "vite-plugin-eslint";
+import {devRouter} from "./vite-devRouter.js";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), eslint()],
+  plugins: [
+    devRouter([
+      ["/create", "/create.html"],
+      ["/myspace", "/myspace.html"],
+    ]),
+    react(),
+    eslint(),
+  ],
   build: {
     rollupOptions: {
       input: {
@@ -14,5 +22,6 @@ export default defineConfig({
         myspace: path.resolve(__dirname, "myspace.html"),
       },
     },
+    outDir: "../server/dist"
   },
 });

--- a/server/index.js
+++ b/server/index.js
@@ -6,9 +6,9 @@ import dotenv from "dotenv";
 
 import { authMiddleware, catchAuthError } from "./middleware/authMiddleware.js";
 import authRouter from "./router/authRouter.js";
+import redirectRouter from "./router/redirectRouter.js";
 import pageRouter from "./router/pageRouter.js";
 import testRouter from "./router/testRouter.js";
-import devRedirectRouter from "./router/devRedirectRouter.js";
 import { HttpError } from "./utils/httpError.js";
 import { HTTP_STATUS } from "./utils/constants.js";
 import { startRedis } from "./model/accessTokenStore.js";
@@ -42,11 +42,11 @@ app.use(["/test/getData"], catchAuthError);
 // api routing
 app.use("/auth", authRouter);
 app.use("/test", testRouter);
+app.use("/", redirectRouter);
 
 // page routing
 if (process.env.NODE_ENV === "development") {
   console.log("dev!");
-  app.use("/", devRedirectRouter);
   app.use(
     "/",
     proxy("http://localhost:5173", {

--- a/server/router/pageRouter.js
+++ b/server/router/pageRouter.js
@@ -4,16 +4,13 @@ import path from "node:path";
 const router = express.Router();
 
 router.get("/", (req, res) => {
-  console.log("this is main page!");
   res.sendFile(path.resolve("./dist/index.html"));
 });
 router.get("/create", async (req, res) => {
-  if (req.userid == null) return res.redirect("/");
-  res.sendFile(path.resolve("../client/dist/create.html"));
+  res.sendFile(path.resolve("./dist/create.html"));
 });
 router.get("/myspace", async (req, res) => {
-  console.log("this is myspace");
-  res.sendFile(path.resolve("../client/dist/myspace.html"));
+  res.sendFile(path.resolve("./dist/myspace.html"));
 });
 
 export default router;

--- a/server/router/redirectRouter.js
+++ b/server/router/redirectRouter.js
@@ -1,13 +1,11 @@
 import express from "express";
+import path from "node:path";
 
 const router = express.Router();
 
-router.get("/create", (req, res) => {
+router.get("/create", (req, res, next) => {
   if (req.userid == null) return res.redirect("/");
-  res.redirect("/create.html");
-});
-router.get("/myspace", (req, res) => {
-  res.redirect("/myspace.html");
+  next();
 });
 
 export default router;


### PR DESCRIPTION
## 세부 진행 상황
-chore: vite 빌드 위치(client/dist -> server/dist) 변경
-chore: vite 빌드 위치 변경에 따른 프로덕션 페이지 라우팅 경로 수정
-refactor: /create -> 메인으로 리다이렉트하는 공통 로직을 미들웨어로 분리
-style: prettier eslint 설정의 캐리지 리턴 규칙 제거

## devRouter 플러그인 사용법
```javascript
devRouter([
	["/create", "/create.html"],
	["/myspace", "/myspace.html"],
	["/myspace/*/*", "/myspace.html"],
	[/^\/space\/(a-z)+/, "/space.html"],
])
```
devRouter는 vite 자체적으로 복잡한 라우팅이 요구되는 멀티 페이지 어플리케이션을 구현할 때, 좀 더 쉽게 사용할 수 있습니다.
인자로 배열이 들어가며, 각 배열의 원소는 [string|RegExp, string]의 형태를 가집니다.
앞에 있는 요소는 라우팅할 페이지이며, 뒤에 있는 요소는 클라이언트 프로젝트 루트 폴더에서 실제 페이지가 존재하는 상대경로입니다. 예시로, `["/create", "/create.html"]`은 `/create` 요청을 보냈을 때 `/create.html` 페이지를 반환합니다.
와일드 카드와 정규 표현식도 지원합니다. 조건과 일치하는 모든 페이지에 대해 다른 페이지로 라우팅을 해 줍니다. 예시로, `["/myspace/*/*", "/myspace.html"]`은 `/myspace/123/456`이나 `/myspace/monument/gallery` 등의 요청이 오면 `/myspace.html`을 반환합니다.