### PR TITLE
fix: 토스트 메시지 관련 버그 수정

### DIFF
--- a/client/src/MySpacePage/components/ORBControls.tsx
+++ b/client/src/MySpacePage/components/ORBControls.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { OrbitControls } from "@react-three/drei";
 import lockStore from "../../store/lock.store";
 import toastStore from "../../store/toast.store";
-import { TOAST_ERROR } from "../../components/Toast/ToastList";
+import TOAST from "../../components/Toast/ToastList";
 export default function ORBControls() {
   const { locked, setLocked } = lockStore();
   const { addToast } = toastStore();
@@ -21,7 +21,7 @@ export default function ORBControls() {
       if (event.code !== "KeyE") return;
       if (!canSwitch) {
         console.log("toast push");
-        addToast(TOAST_ERROR);
+        addToast(TOAST.ERROR());
         return;
       }
       setLocked(true);

--- a/client/src/components/Toast/Toast.tsx
+++ b/client/src/components/Toast/Toast.tsx
@@ -1,57 +1,67 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { IToast } from "../../@types/common";
 import toastStore from "../../store/toast.store";
 import "./toast.scss";
+
 interface ToastProps {
   position: string;
   autoDelete: boolean;
   autoDeleteTime: number;
 }
 
+interface ToastItemProps {
+  toast: IToast;
+  position: string;
+  autoDelete: boolean;
+  autoDeleteTime: number;
+}
+
+function ToastItem({ toast, position, autoDelete, autoDeleteTime }: ToastItemProps) {
+  const { removeToast } = toastStore();
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (autoDelete) removeToast(toast);
+    }, autoDeleteTime);
+
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return (
+    <div
+      className={`notification toast ${position}`}
+      style={{ backgroundColor: toast.backgroundColor }}
+      onClick={() => removeToast(toast)}
+    >
+      <div className="notification-image">
+        <img src={toast.icon} alt="" />
+      </div>
+      <div>
+        <p className="notification-type">{toast.type}</p>
+        <p className="notification-message">{toast.description}</p>
+      </div>
+    </div>
+  );
+}
+
 Toast.defaultProps = {
   position: "bottom-right",
 };
+
 export function Toast({ position, autoDelete, autoDeleteTime }: ToastProps) {
   const { toastList } = toastStore();
-  const [list, setList] = useState(toastList);
 
-  useEffect(() => {
-    setList(toastList);
-  }, [toastList, list]);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (autoDelete && toastList.length && list.length) {
-        deleteToast(toastList[0].id);
-      }
-    }, autoDeleteTime);
-    return () => {
-      clearInterval(interval);
-    };
-  }, [toastList, autoDelete, autoDeleteTime, list]);
-
-  function deleteToast(id: number) {
-    const index = list.findIndex((e) => e.id === id);
-    list.splice(index, 1);
-    const toastListItem = toastList.findIndex((e) => e.id === id);
-    toastList.splice(toastListItem, 1);
-    setList([...list]);
-  }
   return (
-    <>
-      <div className={`notification-container ${position}`}>
-        {list.map((toast: IToast, i) => (
-          <div key={i} className={`notification toast ${position}`} style={{ backgroundColor: toast.backgroundColor }}>
-            <div className="notification-image">
-              <img src={toast.icon} alt="" />
-            </div>
-            <div>
-              <p className="notification-type">{toast.type}</p>
-              <p className="notification-message">{toast.description}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </>
+    <div className={`notification-container ${position}`}>
+      {toastList.map((toast: IToast) => (
+        <ToastItem
+          key={toast.id}
+          toast={toast}
+          position={position}
+          autoDelete={autoDelete}
+          autoDeleteTime={autoDeleteTime}
+        />
+      ))}
+    </div>
   );
 }

--- a/client/src/components/Toast/ToastList.ts
+++ b/client/src/components/Toast/ToastList.ts
@@ -3,31 +3,41 @@ import errorIcon from "../../assets/images/toast-icon-error.svg";
 import infoIcon from "../../assets/images/toast-icon-info.svg";
 import warningIcon from "../../assets/images/toast-icon-warning.svg";
 
-export const TOAST_SUCCESS = {
-  id: Math.floor(Math.random() * 101 + 1),
-  type: "SUCCESS",
-  description: "This is a success toast component",
-  backgroundColor: "#5cb85c",
-  icon: checkIcon,
-};
-export const TOAST_ERROR = {
-  id: Math.floor(Math.random() * 101 + 1),
-  type: "ERROR",
-  description: "This is an error toast component",
-  backgroundColor: "#d9534f",
-  icon: errorIcon,
-};
-export const TOAST_INFO = {
-  id: Math.floor(Math.random() * 101 + 1),
-  type: "INFO",
-  description: "This is an info toast component",
-  backgroundColor: "#5bc0de",
-  icon: infoIcon,
-};
-export const TOAST_WARNING = {
-  id: Math.floor(Math.random() * 101 + 1),
-  type: "WARNING",
-  description: "This is a warning toast component",
-  backgroundColor: "#f0ad4e",
-  icon: warningIcon,
+export default {
+  SUCCESS(description = "This is a success toast component") {
+    return {
+      id: Math.floor(Math.random() * 100001 + 1),
+      type: "SUCCESS",
+      description,
+      backgroundColor: "#5cb85c",
+      icon: checkIcon,
+    };
+  },
+  ERROR(description = "This is a error toast component") {
+    return {
+      id: Math.floor(Math.random() * 100001 + 1),
+      type: "ERROR",
+      description,
+      backgroundColor: "#d9534f",
+      icon: errorIcon,
+    };
+  },
+  INFO(description = "This is a info toast component") {
+    return {
+      id: Math.floor(Math.random() * 100001 + 1),
+      type: "INFO",
+      description,
+      backgroundColor: "#5bc0de",
+      icon: infoIcon,
+    };
+  },
+  WARNING(description = "This is a warning toast component") {
+    return {
+      id: Math.floor(Math.random() * 100001 + 1),
+      type: "WARNING",
+      description,
+      backgroundColor: "#f0ad4e",
+      icon: warningIcon,
+    };
+  },
 };

--- a/client/src/store/toast.store.ts
+++ b/client/src/store/toast.store.ts
@@ -4,6 +4,7 @@ import { IToast } from "../@types/common";
 interface ToastStore {
   toastList: IToast[];
   addToast: (toast: IToast) => void;
+  removeToast: (toast: IToast) => void;
 }
 
 const toastStore = create<ToastStore>((set) => ({
@@ -12,6 +13,15 @@ const toastStore = create<ToastStore>((set) => ({
     set((state) => ({
       toastList: [...state.toastList, toast],
     })),
+  removeToast: (toast: IToast) =>
+    set((state) => {
+      const index = state.toastList.findIndex((e) => e === toast);
+      const newToastList = [...state.toastList];
+      newToastList.splice(index, 1);
+      return {
+        toastList: newToastList,
+      };
+    }),
 }));
 
 export default toastStore;


### PR DESCRIPTION
## 배경상황
토스트 메시지가 2초에 1번씩 너무 늦게 사라지며, 생성될 때는 1개씩 생성되나 사라질 때 2개가 같이 생성되는 문제가 있었음.

## 원인
간단히 설명하자면, 완전히 동일한 배열의 참조를 갖는 두 변수가 2번 배열을 지우는 것을 호출하기 때문입니다. 이렇게 된 원인을 설명하자면 좀 복잡합니다.
```javascript
export const TOAST_ERROR = {
  id: Math.floor(Math.random() * 101 + 1),
  type: "ERROR",
  description: "This is an error toast component",
  backgroundColor: "#d9534f",
  icon: errorIcon,
};
```
토스트를 추가할 때 TOAST_ERROR라는 객체를 가져와서 toastStore에 집어넣습니다. 이때, TOAST_ERROR는 단순한 객체 상수이며, `Math.floor(Math.random() * 101 + 1)`는 **모듈이 최초로 호출될 때 단 한 번만 호출**됩니다. 따라서, **모든 TOAST_ERROR는 동일한 id를 갖습니다**.

```javascript
const { toastList } = toastStore();
const [list, setList] = useState(toastList);
```
Toast 컴포넌트가 생성되면 먼저, toastList 배열을 가져오고, useState로 toastList 배열을 바로 list에 추가합니다. 이 때, list 변수에는 toastList가 참조하는 배열 그 자체가 들어가게 됩니다. **list와 toastList는 완전히 똑같은 배열**인 것이죠.
```javascript
function deleteToast(id: number) {
  const index = list.findIndex((e) => e.id === id);
  list.splice(index, 1);
  const toastListItem = toastList.findIndex((e) => e.id === id);
  toastList.splice(toastListItem, 1);
  setList([...list]);
}
```
이후, 2초에 1번 deleteToast가 호출됩니다. 먼저 list에서 id를 찾아 인덱스를 반환하고, 해당하는 인덱스의 원소를 배열에서 삭제합니다. 이때 삭제 전과 삭제 후의 list가 가리키는 배열은 동일합니다. 그리고 toastList에도 동일한 작업을 반복합니다. **모든 TOAST_ERROR의 id는 동일**하므로, 배열에 값이 남아 있다면 toastList 역시 id를 찾아 인덱스를 반환할 수 있습니다. toastList의 원소 삭제를 수행합니다. 이때 삭제 전과 삭제 후의 toastList가 가리키는 배열과 list가 가리키는 배열은 동일합니다. 즉, **동일한 배열의 원소가 2개 삭제**됩니다. 마지막으로 setList에 스프레드 연산자로 복제한 배열을 넣어 호출하여, 리렌더링을 유도합니다. list에 저장된 배열과 [...list]는 다른 배열을 가리킵니다.
```javascript
useEffect(() => {
  console.log({ toastList, list });
  setList(toastList);
}, [toastList, list]);
```
deleteToast에서 list가 가리키는 값은 setList([...list])를 호출했으므로 deleteToast를 수행하기 전과 달라졌으나, toastList가 가리키는 값은 달라지지 않습니다. list의 값이 달라졌으므로 useEffect가 호출됩니다. 이때 setList(toastList)를 수행하여, **toastList가 가리키는 배열과 list가 가리키는 배열이 동일하게 되어집니다**. 따라서 deleteToast를 호출한 이후에도 계속 list와 toastList는 동일한 배열을 가리키며, 이 오류가 무한히 지속됩니다.

## 해결방법
```typescript
removeToast: (toast: IToast) =>
  set((state) => {
    const index = state.toastList.findIndex((e) => e === toast);
    const newToastList = [...state.toastList];
    newToastList.splice(index, 1);
    return {
      toastList: newToastList,
    };
  }),
```
토스트 리스트 삭제 로직을 toastStore에 추가하고, 기존의 state로 관리하던 상태는 삭제했습니다. removeToast에서 변경하는 toastList 객체는 이전 toastList 객체와 다른 객체를 참조하도록 변경하여, zustand에서 toastList를 참조하는 객체가 리렌더링이 일어나도록 했습니다. 왜냐하면 **객체의 참조가 달라져야 리렌더링이 되거든요**.

```typescript
function ToastItem({ toast, position, autoDelete, autoDeleteTime }: ToastItemProps) {
  const { removeToast } = toastStore();

  useEffect(() => {
    const timeout = setTimeout(() => {
      if (autoDelete) removeToast(toast);
    }, autoDeleteTime);

    return () => clearTimeout(timeout);
  }, []);
```
ToastIem이라는 자식 컴포넌트를 새로 만들었으며, useEffect를 통해 컴포넌트가 처음 렌더링되면 개별적으로 자기 자신을 삭제하도록 하였습니다. 이를 통해 독립적인 토스트 삭제 로직을 구성할 수 있으며, 토스트를 클릭하면 자기 자신을 삭제하도록 하는 것도 쉽게 구현할 수 있습니다.

```typescript
export default {
  SUCCESS(description = "This is a success toast component") {
    return {
      id: Math.floor(Math.random() * 100001 + 1),
      type: "SUCCESS",
      description,
      backgroundColor: "#5cb85c",
      icon: checkIcon,
    };
  },
```
ToastList.ts도 객체 리턴 방식이 아닌 함수 리턴 방식을 사용하여, 함수가 호출될 때마다 id를 변경하도록 하여, id로 각 toast 객체를 구분할 수 있도록 했습니다. 이로 인해 toast.id를 리액트 배열 렌더링의 key로 사용할 수 있어, toastList의 아이템이 중간에 사라져도 엉뚱한 아이템이 삭제되지 않도록 만들 수 있습니다.

## 현재 진행상황
- fix: 토스트 메시지가 2개씩 사라지는 오류 수정
- fix: 토스트 메시지가 너무 늦게 사라지는 오류 수정
- modify: 토스트 생성 함수 추가. 이제 정적인 id를 사용하지 않습니다.
- feat: 토스트 메시지를 클릭 시 바로 사라지는 기능 추가