### PR TITLE
chore: IGalleryPageData 타입 변경

### DIFF
--- a/client/src/@types/gallery.ts
+++ b/client/src/@types/gallery.ts
@@ -2,10 +2,15 @@ export interface IKeywordMap {
   [keyword: string]: number;
 }
 
+export interface IGalleryPageSubTitle {
+  text: string;
+  type: "h1" | "h2" | "h3";
+}
+
 export interface IGalleryPageData {
   position: number[];
   title: string;
-  subtitle: string[];
+  subtitle: IGalleryPageSubTitle[];
   keywords: IKeywordMap;
   links?: {
     href: string;

--- a/client/src/GalleryPage/Gallery.tsx
+++ b/client/src/GalleryPage/Gallery.tsx
@@ -5,18 +5,18 @@ import GalleryWorld from "./GalleryWorld";
 import Light from "./mapObjects/Light";
 import MovementController from "./components/MovementController";
 import ViewRotateController from "./components/ViewRotateController";
-// import dummyData from "./dummyData";
+import dummyData from "./dummyData";
 import galleryStore from "../store/gallery.store";
 
 export default function Gallery() {
-  const { data } = galleryStore();
+  // const { data } = galleryStore();
 
   return (
     <Canvas className="canvas-inner" camera={{ fov: 75, near: 0.1, far: 100, position: [0, 1.5, 2] }}>
       <Light />
       <MovementController speed={5} />
       <ViewRotateController />
-      <GalleryWorld data={data as IGalleryMapData} />
+      <GalleryWorld data={dummyData as IGalleryMapData} />
     </Canvas>
   );
 }

--- a/client/src/GalleryPage/GalleryPage.tsx
+++ b/client/src/GalleryPage/GalleryPage.tsx
@@ -25,7 +25,7 @@ export default function GalleryPage() {
 function GalleryLoader({ resource }: { resource: Resource<IGalleryMapData> }) {
   const [user, history] = useParams("gallery", []);
   const { setData } = galleryStore();
-  useResource(resource, { method: "get", url: `/test/gallery/${user}/${history}` }, (res) => setData(res));
+  // useResource(resource, { method: "get", url: `/test/gallery/${user}/${history}` }, (res) => setData(res));
 
   return <Gallery />;
 }

--- a/client/src/GalleryPage/dummyData.ts
+++ b/client/src/GalleryPage/dummyData.ts
@@ -13,7 +13,11 @@ export default {
     {
       position: [20, 0],
       title: "이것은 타이틀이다",
-      subtitle: ["이것은 h1타이틀", "이것도 h1타이틀", "쏜애플 사랑해요"],
+      subtitle: [
+        { text: "이것은 h1타이틀", type: "h1" },
+        { text: "이것도 h1타이틀", type: "h1" },
+        { text: "쏜애플 사랑해요", type: "h2" },
+      ],
       keywords: {
         부스트캠프: 2,
         쏜애플: 3,
@@ -34,7 +38,11 @@ export default {
     {
       position: [0, 20],
       title: "이것은 2번째 타이틀이다",
-      subtitle: ["이것은 h1타이틀", "이것도 h1타이틀", "쏜애플 사랑해요"],
+      subtitle: [
+        { text: "이것은 h1타이틀", type: "h1" },
+        { text: "이것도 h1타이틀", type: "h1" },
+        { text: "쏜애플 사랑해요", type: "h2" },
+      ],
       keywords: {
         부스트캠프: 2,
         쏜애플: 3,
@@ -44,7 +52,11 @@ export default {
     {
       position: [-20, 0],
       title: "이것은 3번째 타이틀이다",
-      subtitle: ["이것은 h1타이틀", "이것도 h1타이틀", "쏜애플 사랑해요"],
+      subtitle: [
+        { text: "이것은 h1타이틀", type: "h1" },
+        { text: "이것도 h1타이틀", type: "h1" },
+        { text: "쏜애플 사랑해요", type: "h2" },
+      ],
       keywords: {
         부스트캠프: 2,
         쏜애플: 3,
@@ -54,7 +66,11 @@ export default {
     {
       position: [0, -20],
       title: "이것은 4번째 타이틀이다",
-      subtitle: ["이것은 h1타이틀", "이것도 h1타이틀", "쏜애플 사랑해요"],
+      subtitle: [
+        { text: "이것은 h1타이틀", type: "h1" },
+        { text: "이거는 h2타이틀", type: "h2" },
+        { text: "쏜애플 사랑해요", type: "h2" },
+      ],
       keywords: {
         부스트캠프: 2,
         쏜애플: 3,
@@ -64,7 +80,7 @@ export default {
     {
       position: [40, 0],
       title: "이것은 첫번쨰랑 이어진 타이틀이다",
-      subtitle: ["부스트캠프 사랑해요"],
+      subtitle: [{ text: "부스트캠프 사랑해요", type: "h2" }],
       keywords: {
         부스트캠프: 1,
         사랑해요: 1,

--- a/server/model/galleryDummyData.js
+++ b/server/model/galleryDummyData.js
@@ -13,7 +13,7 @@ export default {
     {
       position: [20, 0],
       title: "이것은 타이틀이다",
-      subtitle: ["이것은 h1타이틀", "이것도 h1타이틀", "쏜애플 사랑해요"],
+      subtitle: [{text:"이것은 h1타이틀", type:"h1"}, {text:"이것도 h1타이틀", type:"h1"}, {text:"쏜애플 사랑해요", type:"h2"}],
       keywords: {
         부스트캠프: 2,
         쏜애플: 3,
@@ -34,7 +34,7 @@ export default {
     {
       position: [0, 20],
       title: "이것은 2번째 타이틀이다",
-      subtitle: ["이것은 h1타이틀", "이것도 h1타이틀", "쏜애플 사랑해요"],
+      subtitle: [{text:"이것은 h1타이틀", type:"h1"}, {text:"이것도 h1타이틀", type:"h1"}, {text:"쏜애플 사랑해요", type:"h2"}],
       keywords: {
         부스트캠프: 2,
         쏜애플: 3,
@@ -44,7 +44,7 @@ export default {
     {
       position: [-20, 0],
       title: "이것은 3번째 타이틀이다",
-      subtitle: ["이것은 h1타이틀", "이것도 h1타이틀", "쏜애플 사랑해요"],
+      subtitle: [{text:"이것은 h1타이틀", type:"h1"}, {text:"이것도 h1타이틀", type:"h1"}, {text:"쏜애플 사랑해요", type:"h2"}],
       keywords: {
         부스트캠프: 2,
         쏜애플: 3,
@@ -54,7 +54,7 @@ export default {
     {
       position: [0, -20],
       title: "이것은 4번째 타이틀이다",
-      subtitle: ["이것은 h1타이틀", "이것도 h1타이틀", "쏜애플 사랑해요"],
+      subtitle: [{text:"이것은 h1타이틀", type:"h1"}, {text:"이거는 h2타이틀", type:"h2"}, {text:"쏜애플 사랑해요", type:"h2"}],
       keywords: {
         부스트캠프: 2,
         쏜애플: 3,
@@ -64,7 +64,7 @@ export default {
     {
       position: [40, 0],
       title: "이것은 첫번쨰랑 이어진 타이틀이다",
-      subtitle: ["부스트캠프 사랑해요"],
+      subtitle: [{text:"부스트캠프 사랑해요", type:"h2"}],
       keywords: {
         부스트캠프: 1,
         사랑해요: 1,


### PR DESCRIPTION
## Summary
각 갤러리 공간을 렌더링할 타입이 변경되었습니다.

## Context
갤러리 공간의 각 페이지에 부제목에 해당하는 비석을 h1~h3으로 분리해서 크기를 다르게 렌더링하고 싶었으므로, 부제목의 문자열 정보에 더해서 해당 제목이 무슨 유형에 해당하는지에 대한 정보를 알 필요가 있었습니다.

## Description
변경된 타입은 다음과 같습니다. 백엔드는 이에 유념하여 API를 작성해 주세요
```typescript
export interface IGalleryPageSubTitle {
  text: string;
  type: "h1" | "h2" | "h3";
}

export interface IGalleryPageData {
  position: number[];
  title: string;
  subtitle: IGalleryPageSubTitle[];
  keywords: IKeywordMap;
  links?: {
    href: string;
    favicon?: string;
  };
  imagePixel?: number[][];
}
```