### PR TITLE
feat: 메인 워드클라우드 추가, 빌보드 기능 재작성

### DIFF
--- a/client/src/GalleryPage/GalleryWorld.tsx
+++ b/client/src/GalleryPage/GalleryWorld.tsx
@@ -21,7 +21,7 @@ export default function GalleryWorld({ data }: GalleryWorldProps) {
 
   return (
     <>
-      <GalleryCenterIsland />
+      <GalleryCenterIsland keywords={totalKeywords} />
       {pages.map((pageData: IGalleryPageData, i: number) => {
         const id = `${pageData.title}__${i}`;
         return <GalleryPageIsland {...pageData} key={id} />;

--- a/client/src/GalleryPage/mapObjects/AnimatedTitle.tsx
+++ b/client/src/GalleryPage/mapObjects/AnimatedTitle.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import { animated, Interpolation, useSpring } from "@react-spring/three";
 
 import Balloon from "./Balloon";
+import { useBillboard } from "../../hooks/useBillboard";
 
 import MapoFlowerIsland from "../../assets/fonts/MapoFlowerIsland.otf";
 import { generateRandomPastelColors } from "../../utils/random";
@@ -18,7 +19,7 @@ export default function AnimatedTitle({ position, text }: AnimatedTitleProps) {
   const [active, setActive] = useState(0);
   const [action, setAction] = useState(false);
   const { camera } = useThree();
-  const textGroupRef = useRef<THREE.Group>(null);
+  const textGroupRef = useBillboard({ follow: !action });
 
   const { spring } = useSpring({
     spring: active,
@@ -36,7 +37,6 @@ export default function AnimatedTitle({ position, text }: AnimatedTitleProps) {
   const rotation = spring.to([0, 1], [0, Math.PI * 4]);
 
   useFrame(() => {
-    if (!action) textGroupRef.current?.lookAt(camera.position);
     const { x, z: y } = camera.position;
 
     const distance = Math.abs(x - position[0]) + Math.abs(y - position[2]);

--- a/client/src/GalleryPage/mapObjects/AnimatedTitle.tsx
+++ b/client/src/GalleryPage/mapObjects/AnimatedTitle.tsx
@@ -1,0 +1,70 @@
+import { useMemo, useRef, useState } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import { Text } from "@react-three/drei";
+import { animated, Interpolation, useSpring } from "@react-spring/three";
+
+import Balloon from "./Balloon";
+
+import MapoFlowerIsland from "../../assets/fonts/MapoFlowerIsland.otf";
+import { generateRandomPastelColors } from "../../utils/random";
+import { COLORS } from "../../@types/colors";
+
+interface AnimatedTitleProps {
+  position: [x: number, y: number, z: number];
+  text: string;
+}
+
+export default function AnimatedTitle({ position, text }: AnimatedTitleProps) {
+  const [active, setActive] = useState(0);
+  const [action, setAction] = useState(false);
+  const { camera } = useThree();
+  const textGroupRef = useRef<THREE.Group>(null);
+
+  const { spring } = useSpring({
+    spring: active,
+    config: { tension: 500, friction: 150, precision: 0.04 },
+    onStart: () => setAction(true),
+    onRest: () => setAction(false),
+  });
+
+  const textScale: Interpolation<number, number> = useMemo(() => spring.to([0, 1], [-2, 4]), []);
+  const balloonScale: Interpolation<number, number> = useMemo(() => spring.to([0, 1], [0, 1]), []);
+  const textY: Interpolation<number, number> = useMemo(() => spring.to([0, 1], [-2, 6]), []);
+  const balloonY: Interpolation<number, number> = useMemo(() => spring.to([0, 1], [-2, 8]), []);
+  const randomColors = useMemo<keyof typeof COLORS>(() => generateRandomPastelColors()[0], []);
+  const color: Interpolation<number, COLORS> = spring.to([0, 1], [COLORS.SKY400, COLORS[randomColors]]);
+  const rotation = spring.to([0, 1], [0, Math.PI * 4]);
+
+  useFrame(() => {
+    if (!action) textGroupRef.current?.lookAt(camera.position);
+    const { x, z: y } = camera.position;
+
+    const distance = Math.abs(x - position[0]) + Math.abs(y - position[2]);
+
+    if (distance < 15) {
+      if (!active) setActive(+!active);
+    } else {
+      if (active) setActive(+!active);
+    }
+  });
+
+  return (
+    <>
+      <animated.group ref={textGroupRef} position={position} position-y={textY}>
+        <animated.mesh rotation-y={rotation} scale={textScale} onClick={() => setActive(+!active)}>
+          <Text
+            visible={!(!active && !action)}
+            font={MapoFlowerIsland}
+            color="black"
+            fontSize={0.1}
+            anchorX="center"
+            anchorY="middle"
+          >
+            {text}
+          </Text>
+        </animated.mesh>
+      </animated.group>
+      <Balloon position={position} positionY={balloonY} scale={balloonScale} color={color} />
+    </>
+  );
+}

--- a/client/src/GalleryPage/mapObjects/GalleryCenterIsland.tsx
+++ b/client/src/GalleryPage/mapObjects/GalleryCenterIsland.tsx
@@ -1,9 +1,16 @@
 import Island from "./Island";
+import MainWordCloud from "./MainWordCloud";
+import { IKeywordMap } from "../../@types/gallery";
 
-export default function GalleryCenterIsland() {
+interface GalleryCenterIslandProps {
+  keywords: IKeywordMap;
+}
+
+export default function GalleryCenterIsland({ keywords }: GalleryCenterIslandProps) {
   return (
     <>
       <Island x={0} z={0} color={0xaaffff} />
+      <MainWordCloud keywords={keywords} position={[0, 2, 0]} scale={0.3} />
     </>
   );
 }

--- a/client/src/GalleryPage/mapObjects/GalleryPageIsland.tsx
+++ b/client/src/GalleryPage/mapObjects/GalleryPageIsland.tsx
@@ -1,150 +1,17 @@
-import { IGalleryPageData, IGalleryPageSubTitle } from "../../@types/gallery";
 import Island from "./Island";
-import React, { useMemo, useRef, useState } from "react";
-import { animated, Interpolation, useSpring } from "@react-spring/three";
-import { Text } from "@react-three/drei";
-import { useFrame, useThree } from "@react-three/fiber";
-import MapoFlowerIsland from "../../assets/fonts/MapoFlowerIsland.otf";
-import Balloon from "./Balloon";
-import { generateRandomPastelColors } from "../../utils/random";
-import MemorialStone from "./MemorialStone";
-import { COLORS } from "../../@types/colors";
+import MemorialStones from "./MemorialStone";
+import AnimatedTitle from "./AnimatedTitle";
 
-interface IStoneInfo {
-  subtitle: IGalleryPageSubTitle;
-  stonePosition: number[];
-}
-
-function calculateMemorialStonePosition(subtitles: IGalleryPageSubTitle[]) {
-  const enalblePositions = [
-    [0, 0],
-    [1, 1],
-    [-1, -1],
-    [2, 0],
-    [-2, 0],
-    [3, 1],
-    [-3, -1],
-  ];
-  let cursor = 0;
-  const stoneInfoList: IStoneInfo[] = [];
-  const h1List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h1");
-  const h2List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h2");
-  const h3List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h3");
-  while (cursor < enalblePositions.length) {
-    if (h1List.length > 0) {
-      const subtitle = h1List.pop();
-      if (subtitle) {
-        stoneInfoList.push({
-          subtitle,
-          stonePosition: enalblePositions[cursor],
-        });
-        cursor++;
-        continue;
-      }
-    } else if (h2List.length > 0) {
-      const subtitle = h2List.pop();
-      if (subtitle) {
-        stoneInfoList.push({
-          subtitle,
-          stonePosition: enalblePositions[cursor],
-        });
-        cursor++;
-        continue;
-      }
-      cursor++;
-      continue;
-    } else if (h3List.length > 0) {
-      const subtitle = h3List.pop();
-      if (subtitle) {
-        stoneInfoList.push({
-          subtitle,
-          stonePosition: enalblePositions[cursor],
-        });
-        cursor++;
-        continue;
-      }
-    } else {
-      break;
-    }
-  }
-  return stoneInfoList;
-}
-
-interface AnimatedTitleProps {
-  position: [x: number, y: number, z: number];
-  text: string;
-}
-
-function AnimatedTitle({ position, text }: AnimatedTitleProps) {
-  const [active, setActive] = useState(0);
-  const [action, setAction] = useState(false);
-  const { camera } = useThree();
-  const textGroupRef = useRef<THREE.Group>(null);
-
-  const { spring } = useSpring({
-    spring: active,
-    config: { tension: 500, friction: 150, precision: 0.04 },
-    onStart: () => setAction(true),
-    onRest: () => setAction(false),
-  });
-
-  const textScale: Interpolation<number, number> = useMemo(() => spring.to([0, 1], [-2, 4]), []);
-  const balloonScale: Interpolation<number, number> = useMemo(() => spring.to([0, 1], [0, 1]), []);
-  const textY: Interpolation<number, number> = useMemo(() => spring.to([0, 1], [-2, 6]), []);
-  const balloonY: Interpolation<number, number> = useMemo(() => spring.to([0, 1], [-2, 8]), []);
-  const randomColors = useMemo(() => generateRandomPastelColors()[0], []);
-  const color: Interpolation<number, COLORS> = spring.to([0, 1], [COLORS.SKY400, COLORS[randomColors]]);
-  const rotation = spring.to([0, 1], [0, Math.PI * 4]);
-
-  useFrame(() => {
-    if (!action) textGroupRef.current?.lookAt(camera.position);
-    const { x, z: y } = camera.position;
-
-    const distance = Math.abs(x - position[0]) + Math.abs(y - position[2]);
-
-    if (distance < 15) {
-      if (!active) setActive(+!active);
-    } else {
-      if (active) setActive(+!active);
-    }
-  });
-
-  return (
-    <>
-      <animated.group ref={textGroupRef} position={position} position-y={textY}>
-        <animated.mesh rotation-y={rotation} scale={textScale} onClick={() => setActive(+!active)}>
-          <Text
-            visible={!(!active && !action)}
-            font={MapoFlowerIsland}
-            color="black"
-            fontSize={0.1}
-            anchorX="center"
-            anchorY="middle"
-          >
-            {text}
-          </Text>
-        </animated.mesh>
-      </animated.group>
-      <Balloon position={position} positionY={balloonY} scale={balloonScale} color={color} />
-    </>
-  );
-}
+import { IGalleryPageData } from "../../@types/gallery";
 
 export default function GalleryPageIsland({ position, subtitle, title }: IGalleryPageData) {
   const [x, z] = position;
-  const stoneInfoList = useMemo(() => {
-    return calculateMemorialStonePosition(subtitle);
-  }, []);
 
   return (
     <>
       <AnimatedTitle position={[x, 0, z]} text={title} />
       <Island x={x} z={z} />
-      {stoneInfoList.map((stoneInfo, i) => {
-        const { subtitle, stonePosition } = stoneInfo;
-        const key = `${subtitle}+${i}`;
-        return <MemorialStone subTitle={subtitle} position={position.map((e, i) => e + stonePosition[i])} key={key} />;
-      })}
+      <MemorialStones position={[x, z]} subtitles={subtitle} />
     </>
   );
 }

--- a/client/src/GalleryPage/mapObjects/MainWordCloud.tsx
+++ b/client/src/GalleryPage/mapObjects/MainWordCloud.tsx
@@ -1,0 +1,163 @@
+import { useMemo } from "react";
+import { Text, Billboard } from "@react-three/drei";
+import { Vector3, Quaternion } from "three";
+
+import { IKeywordMap } from "../../@types/gallery";
+
+import MapoFont from "../../assets/MapoFlowerIsland.otf";
+
+interface IWordPointData {
+  text: string;
+  size: number;
+  fontSize: number;
+}
+
+interface IOrbitData {
+  children: IWordPointData[];
+  radius: number;
+  spiralCount: number;
+}
+
+interface WordObjectProps {
+  data: IWordPointData;
+  position: Vector3 | [x: number, y: number, z: number];
+}
+
+interface WordHelixProps {
+  orbitData: IOrbitData;
+}
+
+interface MainWordCloudProps {
+  keywords: IKeywordMap;
+}
+
+function makeWordsPointData(words: IKeywordMap): IWordPointData[] {
+  const entries = Object.entries(words);
+  const biggestFrequency = entries.reduce((max, [, value]) => Math.max(max, value), 0);
+  const biggestfontSize = 1;
+  const result = [];
+  for (const [text, freq] of entries) {
+    const fontSize = (biggestfontSize * freq) / biggestFrequency;
+    const size = (text.length * freq) / 8;
+    result.push({ text, size, fontSize });
+  }
+  result.sort((a, b) => b.size - a.size);
+  return result.slice(0, 30);
+}
+
+function seperateWordToOrbits(wordData: IWordPointData[]): IOrbitData[] {
+  if (wordData.length === 0) return [];
+
+  const result = [{ children: [wordData[0]], radius: wordData[0].size, spiralCount: 0 }];
+
+  let prevOrbitIndex = 0;
+  let index = 1;
+
+  while (index < wordData.length) {
+    const currentWordData = wordData[index];
+
+    const radius = result[prevOrbitIndex].radius + currentWordData.size;
+    const spiralCount = Math.floor((1.28 * radius) / currentWordData.size / 2) * 2;
+    const maxSpiralLength = radius * spiralCount * 2;
+    const maxChildrenCount = Math.floor((spiralCount * spiralCount) / 0.64);
+
+    const children = [];
+    let spiralLength = 0;
+    let childrenCount = 0;
+    while (spiralLength < maxSpiralLength && childrenCount <= maxChildrenCount && index < wordData.length) {
+      const currentWordData = wordData[index];
+
+      children.push(currentWordData);
+      spiralLength += currentWordData.size;
+      index++;
+      childrenCount++;
+    }
+    if (children.length > 0) {
+      result.push({ children, radius, spiralCount });
+      prevOrbitIndex++;
+    }
+  }
+  return result;
+}
+
+function getHelicalPosition(radius: number, index: number, spiralCount: number) {
+  const toCostanter = (x: number, slope: number) => {
+    return (((x - 0.5) ** 3 + slope * (x - 0.5)) * Math.PI * 4) / (1 + slope * 4) + Math.PI / 2;
+  };
+
+  const theta = toCostanter(index, 0.4);
+  const phi = theta * spiralCount * 2;
+
+  const x = Math.sin(theta) * Math.cos(phi);
+  const y = Math.cos(theta);
+  const z = Math.sin(theta) * Math.sin(phi);
+  return new Vector3(x, y, z).multiplyScalar(radius);
+}
+
+function getDistributeIndex(index: number) {
+  if (index === 0) return 0;
+  if (index === 1) return 1;
+  if (index === 2) return 0.5;
+  const _index = index - 1;
+  const logIndex = Math.floor(Math.log2(_index));
+  const min2PowIndex = 2 ** logIndex;
+
+  const result = (_index - min2PowIndex) / min2PowIndex + 1 / (min2PowIndex * 2);
+
+  if (logIndex % 2) return result;
+  return 1 - result;
+}
+
+function WordObject({ data, position }: WordObjectProps) {
+  const { text, fontSize } = data;
+  return (
+    <Billboard position={position}>
+      <Text font={MapoFont} fontSize={fontSize} color="black" anchorX="center" anchorY="middle">
+        {text}
+      </Text>
+    </Billboard>
+  );
+}
+
+function WordHelix({ orbitData }: WordHelixProps) {
+  const { children, radius, spiralCount } = orbitData;
+  const rotation = new Quaternion().random();
+
+  const toRenderChildren = useMemo<IWordPointData[]>(
+    () =>
+      children
+        .map((value, index) => ({ value, index }))
+        .sort((a, b) => getDistributeIndex(b.index) - getDistributeIndex(a.index))
+        .map(({ value }) => value),
+    [children],
+  );
+
+  return (
+    <>
+      {toRenderChildren.map((child: IWordPointData, i: number) => {
+        const partician = toRenderChildren.length < 2 ? 0 : i / (toRenderChildren.length - 1);
+        const position = getHelicalPosition(radius, partician, spiralCount);
+        position.add(new Vector3().randomDirection().multiplyScalar(0.5));
+        position.applyQuaternion(rotation);
+        return <WordObject data={child} position={position} key={`${child.text}_${i}`} />;
+      })}
+    </>
+  );
+}
+
+export default function MainWordCloud({ keywords, ...props }: MainWordCloudProps) {
+  const [firstOrbit, ...helixOrbits] = useMemo<IOrbitData[]>(() => {
+    const wordData = makeWordsPointData(keywords);
+    return seperateWordToOrbits(wordData);
+  }, []);
+
+  if (firstOrbit == null) return <group {...props} />;
+  return (
+    <group {...props}>
+      <WordObject data={firstOrbit.children[0]} position={[0, 0, 0]} />
+      {helixOrbits.map((orbit: IOrbitData, i: number) => (
+        <WordHelix orbitData={orbit} key={`orbit_${i}`} />
+      ))}
+    </group>
+  );
+}

--- a/client/src/GalleryPage/mapObjects/MemorialStone.tsx
+++ b/client/src/GalleryPage/mapObjects/MemorialStone.tsx
@@ -3,6 +3,7 @@ import { Text } from "@react-three/drei";
 import { useFrame, useThree } from "@react-three/fiber";
 import { Mesh, Vector3 } from "three";
 
+import { useBillboard } from "../../hooks/useBillboard";
 import { IGalleryPageSubTitle } from "../../@types/gallery";
 import MapoFont from "../../assets/MapoFlowerIsland.otf";
 
@@ -100,12 +101,8 @@ function MemorialStone({ subTitle, position }: MemorialStoneProps) {
     return { visibleLetters, invisibleLetters };
   }, []);
 
-  const subtitleMeshRef = useRef<Mesh>(null);
+  const subtitleMeshRef = useBillboard({ lockElevation: true });
   const subtitleRef = useRef<any>();
-
-  useFrame(() => {
-    subtitleMeshRef.current?.lookAt(new Vector3(camera.position.x, 2, camera.position.z));
-  });
 
   useEffect(() => {
     const interval = setInterval(() => {

--- a/client/src/GalleryPage/mapObjects/MemorialStone.tsx
+++ b/client/src/GalleryPage/mapObjects/MemorialStone.tsx
@@ -1,12 +1,79 @@
-import { Billboard, Text } from "@react-three/drei";
-import { useFrame, useThree } from "@react-three/fiber";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Vector3 } from "three";
+import { Text } from "@react-three/drei";
+import { useFrame, useThree } from "@react-three/fiber";
+import { Mesh, Vector3 } from "three";
+
 import { IGalleryPageSubTitle } from "../../@types/gallery";
 import MapoFont from "../../assets/MapoFlowerIsland.otf";
+
+interface MemorialStonesProps {
+  subtitles: IGalleryPageSubTitle[];
+  position: number[];
+}
+
 interface MemorialStoneProps {
   subTitle: IGalleryPageSubTitle;
   position: number[];
+}
+
+interface IStoneInfo {
+  subtitle: IGalleryPageSubTitle;
+  stonePosition: number[];
+}
+
+function calculateMemorialStonePosition(subtitles: IGalleryPageSubTitle[]) {
+  const enalblePositions = [
+    [0, 0],
+    [1, 1],
+    [-1, -1],
+    [2, 0],
+    [-2, 0],
+    [3, 1],
+    [-3, -1],
+  ];
+  let cursor = 0;
+  const stoneInfoList: IStoneInfo[] = [];
+  const h1List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h1");
+  const h2List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h2");
+  const h3List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h3");
+  while (cursor < enalblePositions.length) {
+    if (h1List.length > 0) {
+      const subtitle = h1List.pop();
+      if (subtitle) {
+        stoneInfoList.push({
+          subtitle,
+          stonePosition: enalblePositions[cursor],
+        });
+        cursor++;
+        continue;
+      }
+    } else if (h2List.length > 0) {
+      const subtitle = h2List.pop();
+      if (subtitle) {
+        stoneInfoList.push({
+          subtitle,
+          stonePosition: enalblePositions[cursor],
+        });
+        cursor++;
+        continue;
+      }
+      cursor++;
+      continue;
+    } else if (h3List.length > 0) {
+      const subtitle = h3List.pop();
+      if (subtitle) {
+        stoneInfoList.push({
+          subtitle,
+          stonePosition: enalblePositions[cursor],
+        });
+        cursor++;
+        continue;
+      }
+    } else {
+      break;
+    }
+  }
+  return stoneInfoList;
 }
 
 function textPreProcessing(text: string) {
@@ -22,7 +89,7 @@ function textPreProcessing(text: string) {
   return { visibleLetters, invisibleLetters };
 }
 
-export default function MemorialStone({ subTitle, position }: MemorialStoneProps) {
+function MemorialStone({ subTitle, position }: MemorialStoneProps) {
   const { text, type } = subTitle;
   const [pText, setPText] = useState("");
   const { camera } = useThree();
@@ -33,7 +100,7 @@ export default function MemorialStone({ subTitle, position }: MemorialStoneProps
     return { visibleLetters, invisibleLetters };
   }, []);
 
-  const subtitleMeshRef = useRef<THREE.Mesh>(null);
+  const subtitleMeshRef = useRef<Mesh>(null);
   const subtitleRef = useRef<any>();
 
   useFrame(() => {
@@ -86,6 +153,27 @@ export default function MemorialStone({ subTitle, position }: MemorialStoneProps
           {pText}
         </Text>
       </mesh>
+    </>
+  );
+}
+
+export default function MemorialStones({ subtitles, position }: MemorialStonesProps) {
+  const stoneInfoList = useMemo(() => {
+    return calculateMemorialStonePosition(subtitles);
+  }, []);
+  return (
+    <>
+      {stoneInfoList.map((stoneInfo, i) => {
+        const { subtitle, stonePosition } = stoneInfo;
+        const key = `${subtitle}+${i}`;
+        return (
+          <MemorialStone
+            subTitle={subtitle}
+            position={position.map((e: number, i: number) => e + stonePosition[i])}
+            key={key}
+          />
+        );
+      })}
     </>
   );
 }

--- a/client/src/hooks/useBillboard.ts
+++ b/client/src/hooks/useBillboard.ts
@@ -1,0 +1,50 @@
+import { useRef } from "react";
+import { useThree, useFrame } from "@react-three/fiber";
+import { Object3D, Matrix4, Quaternion, Euler } from "three";
+
+interface LockConfig {
+  lockElevation?: boolean;
+}
+
+const _matrix = new Matrix4();
+const _euler = new Euler(0, 0, 0, "YXZ");
+const _quaternion = new Quaternion();
+
+function getAzimuth(quaternion) {
+  _matrix.makeRotationFromQuaternion(quaternion);
+  const elem = _matrix.elements;
+  const m11 = elem[0],
+    m13 = elem[8];
+  const m23 = elem[9];
+  const m31 = elem[2],
+    m33 = elem[10];
+
+  // const x = Math.asin( - Math.min( Math.max(m23, -1), 1 );
+  if (Math.abs(m23) < 0.9999999) return Math.atan2(m13, m33);
+  else return Math.atan2(-m31, m11);
+}
+
+export function useBillboard({ lockElevation = false }: LockConfig = {}) {
+  const objectRef = useRef<Object3D>();
+  const { camera } = useThree();
+
+  useFrame(() => {
+    if (!objectRef.current) return;
+    const object = objectRef.current;
+
+    _quaternion.copy(camera.quaternion);
+    if (lockElevation) {
+      _euler.y = getAzimuth(_quaternion);
+      _quaternion.setFromEuler(_euler);
+    }
+    object.quaternion.copy(_quaternion);
+
+    if (object.parent) {
+      _matrix.extractRotation(object.parent.matrixWorld);
+      _quaternion.setFromRotationMatrix(_matrix);
+      object.quaternion.premultiply(_quaternion.invert());
+    }
+  });
+
+  return objectRef;
+}

--- a/client/src/hooks/useBillboard.ts
+++ b/client/src/hooks/useBillboard.ts
@@ -4,6 +4,7 @@ import { Object3D, Matrix4, Quaternion, Euler } from "three";
 
 interface LockConfig {
   lockElevation?: boolean;
+  follow?: boolean;
 }
 
 const _matrix = new Matrix4();
@@ -24,12 +25,12 @@ function getAzimuth(quaternion) {
   else return Math.atan2(-m31, m11);
 }
 
-export function useBillboard({ lockElevation = false }: LockConfig = {}) {
+export function useBillboard({ lockElevation = false, follow = true }: LockConfig = {}) {
   const objectRef = useRef<Object3D>();
   const { camera } = useThree();
 
   useFrame(() => {
-    if (!objectRef.current) return;
+    if (!follow || !objectRef.current) return;
     const object = objectRef.current;
 
     _quaternion.copy(camera.quaternion);


### PR DESCRIPTION
## Summery
전체 공간의 통계 워드클라우드를 렌더링하고, 빌보드 기능을 재작성했습니다.

## Context
React-three/drei에서 사용되는 Billboard 컴포넌트는 아주 잘 동작하나, 빌보드 사용 객체의 부모 객체가 다른 방향으로 회전하면 오류가 발생합니다. 
```typescript
useFrame(({ camera }) => {
  if (!follow || !localRef.current) return

  // save previous rotation in case we're locking an axis
  const prevRotation = localRef.current.rotation.clone()

  // always face the camera
  localRef.current.quaternion.copy(camera.quaternion)

  // readjust any axis that is locked
  if (lockX) localRef.current.rotation.x = prevRotation.x
  if (lockY) localRef.current.rotation.y = prevRotation.y
  if (lockZ) localRef.current.rotation.z = prevRotation.z
})
```
빌보드 컴포넌트 내부에서는 카메라의 사원수 각도와 내부 컴포넌트의 각도를 일치시켜서 빌보드 기능을 구현하고 있으나, 부모 객체가 다른 회전각을 갖고 있으면 부모 객체의 회전각+자식 객체의 카메라 회전각이 동시에 적용되어서 빌보드 기능이 깨져버리는 오류가 있었습니다.
```javascript
if ( parent ) {
  // _m1은 Matrix4 객체, _q1은 Quaternion 객체임.
  _m1.extractRotation( parent.matrixWorld );
  _q1.setFromRotationMatrix( _m1 );
  this.quaternion.premultiply( _q1.invert() );
}
```
three.js의 Object3D.prototype.lookAt 메소드는 부모 객체가 다른 회전각을 갖고 있어도 잘 동작하는데, 이유는 위의 각도 때문입니다. 부모 객체의 월드 회전각을 가져와서, 계산된 자식 객체의 각도에 부모 월드 회전각을 반대 방향으로 적용시키는 로직을 갖고 있습니다. 해당 부분을 Billboard 컴포넌트의 로직에 붙이면 부모 객체가 아무리 회전해도 자식이 카메라를 바라보는 빌보드 로직을 구성할 수 있습니다.

## Description
- 메인페이지의 워드클라우드를 추가했습니다.
- 중앙 워드클라우드에 빌보드를 적용했습니다.
- Animated Title과 Memorial Stone 컴포넌트에 사용되는 ~~옳게 되지 못한~~ 빌보드 기능을 커스텀 훅으로 분리하여, 해당 컴포넌트들이 useBillboard를 사용할 수 있도록 했습니다.

## Tribia
분명 워드클라우드 그까이꺼 하고 생각했었지만... 굉장히 어렵습니다