### PR TITLE
Feat/notiondatabase

### DIFF
--- a/server/service/dataProcessService.js
+++ b/server/service/dataProcessService.js
@@ -118,7 +118,7 @@ function getGroups(keywords) {
     for (let i = 0; i < sortedPageKeywords.length; i++) {
       for (let j = 0; j < totalKeywordSize; j++) {
         if (sortedTotalKeywords[j] === sortedPageKeywords[i]) {
-          res[sortedTotalKeywords[i]].push(key);
+          res[sortedTotalKeywords[j]].push(key);
           isChoice = true;
           break;
         }

--- a/server/service/notionService.js
+++ b/server/service/notionService.js
@@ -9,7 +9,6 @@ export async function getRawContentsFromNotion(notionAccessToken, period) {
   const notion = new Client({ auth: notionAccessToken });
 
   return await getPages(notion, limitTime);
-
 }
 
 async function getPages(notion, limitTime) {
@@ -225,6 +224,7 @@ function processPageData(notion, data) {
         }
         break;
       case "toggle":
+        //토글 내부를 못 읽는 듯 함
         if (getTextFromTextObject(val.toggle?.rich_text).length > 0) {
           res.paragraph = [...res.paragraph, ...getTextFromTextObject(val.toggle?.rich_text)];
         }
@@ -238,16 +238,39 @@ function processPageData(notion, data) {
         break;
       case "image": //이미지, img.[external||file].url에 링크 존재
         //이미지 내부 타입에 따라서 뒤에 오는 변수가 달라짐
+        if (val.image.type === "external" && val.image.external?.url) {
+          res.image.push(val.image.external.url);
+        } else if (val.image.type === "file" && val.image.file?.url) {
+          res.image.push(val.image.file.url);
+        }
         // console.log("이미지: ", val.image);
         break;
       case "embed": //외부 링크 임베드 embed.url에 링크 존재
         // console.log("임베드링크: ", val.embed);
+        if (val.embed?.url) {
+          res.links.push({
+            href: val.embed.link,
+            favicon: "",
+          });
+        }
         break;
       case "bookmark": //북마크, bookmark.url에 링크 존재
         // console.log("북마크: ", val.bookmark);
+        if (val.bookmark?.url) {
+          res.links.push({
+            href: val.bookmark.url,
+            favicon: "",
+          });
+        }
         break;
       case "link_preview": //링크, link_preview.url
         // console.log("링크 프리뷰: ", val.link_preview);
+        if (val.link_preview?.url) {
+          res.links.push({
+            href: val.link_preview.url,
+            favicon: "",
+          });
+        }
         break;
       case "table":
       case "table_row":


### PR DESCRIPTION
# Summary
노션 데이터에서 url, 이미지 경로 추출
# Context
오후 작업을 위해 간략하게나마 url과 이미지 경로를 추출함
# Description
- notionService로 받아온 결과물을 rawContent라고 할 때,
  Object.keys(rawContent).forEach( pageId => rawContent[pageId].links || .image )같은 명령어로 페이지 내 링크와 이미지 정보를  추출할 수 있음

- 단, 아직은 별도의 처리 없이 url만 적어놓은 경우나 토글 내부에 있는 데이터를 읽어오지 못해서 전부 다 읽어오진 못함.