### PR TITLE
feat: useBillboard 및 useRef관련 타입에러 해결, suspender 에러처리 관련로직 추가

### DIFF
--- a/client/src/GalleryPage/Gallery.tsx
+++ b/client/src/GalleryPage/Gallery.tsx
@@ -7,8 +7,6 @@ import MovementController from "./components/MovementController";
 import ViewRotateController from "./components/ViewRotateController";
 import dummyData from "./dummyData";
 
-// const camera = new THREE.PerspectiveCamera(75, 1920 / 1080, 0.1, 100);
-// camera.position.set(0, 1.5, 2);
 export default function Gallery() {
   return (
     <Canvas className="canvas-inner" camera={{ fov: 75, near: 0.1, far: 100, position: [0, 1.5, 2] }}>

--- a/client/src/GalleryPage/mapObjects/AnimatedTitle.tsx
+++ b/client/src/GalleryPage/mapObjects/AnimatedTitle.tsx
@@ -19,7 +19,7 @@ export default function AnimatedTitle({ position, text }: AnimatedTitleProps) {
   const [active, setActive] = useState(0);
   const [action, setAction] = useState(false);
   const { camera } = useThree();
-  const textGroupRef = useBillboard({ follow: !action });
+  const textGroupRef = useBillboard<THREE.Group>({ follow: !action });
 
   const { spring } = useSpring({
     spring: active,

--- a/client/src/GalleryPage/mapObjects/MainWordCloud.tsx
+++ b/client/src/GalleryPage/mapObjects/MainWordCloud.tsx
@@ -155,7 +155,7 @@ function WordHelix({ orbitData }: WordHelixProps) {
 }
 
 export default function MainWordCloud({ keywords, ...props }: MainWordCloudProps) {
-  const objectRef = useRef<Group>();
+  const objectRef = useRef<Group>(null);
 
   const [firstOrbit, ...helixOrbits] = useMemo<IOrbitData[]>(() => {
     const wordData = makeWordsPointData(keywords);

--- a/client/src/GalleryPage/mapObjects/MemorialStone.tsx
+++ b/client/src/GalleryPage/mapObjects/MemorialStone.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Text } from "@react-three/drei";
-import { useFrame, useThree } from "@react-three/fiber";
-import { Mesh, Vector3 } from "three";
-
 import { useBillboard } from "../../hooks/useBillboard";
 import { IGalleryPageSubTitle } from "../../@types/gallery";
 import MapoFont from "../../assets/MapoFlowerIsland.otf";
+import { Object3D } from "three";
 
 interface MemorialStonesProps {
   subtitles: IGalleryPageSubTitle[];
@@ -91,9 +89,8 @@ function textPreProcessing(text: string) {
 }
 
 function MemorialStone({ subTitle, position }: MemorialStoneProps) {
-  const { text, type } = subTitle;
+  const { text } = subTitle;
   const [pText, setPText] = useState("");
-  const { camera } = useThree();
 
   const { visibleLetters, invisibleLetters } = useMemo(() => {
     const { visibleLetters, invisibleLetters } = textPreProcessing(text);
@@ -101,11 +98,12 @@ function MemorialStone({ subTitle, position }: MemorialStoneProps) {
     return { visibleLetters, invisibleLetters };
   }, []);
 
-  const subtitleMeshRef = useBillboard({ lockElevation: true });
-  const subtitleRef = useRef<any>();
+  const subtitleMeshRef = useBillboard<THREE.Mesh>({ lockElevation: true });
+  const subtitleRef = useRef<Object3D>(null);
 
   useEffect(() => {
     const interval = setInterval(() => {
+      if (!subtitleRef.current) return;
       subtitleRef.current.position.y -= 1;
       if (subtitleRef.current.position.y < 0) {
         if (invisibleLetters.length > 0) {

--- a/client/src/components/SpaceCreater/index.tsx
+++ b/client/src/components/SpaceCreater/index.tsx
@@ -51,7 +51,8 @@ export default function SpaceCreater({ resource, onSubmit }: SpaceCreaterProps) 
 }
 
 function Data({ resource }: { resource: Resource | null }) {
-  resource?.read({ method: "get", url: "/test/getData" });
+  const res = resource?.read({ method: "get", url: "/test/getData" });
+  if (!res || res?.error) return <>에러가 발생했습니다.</>;
   window.location.href = `/gallery/${v4()}/${v4()}`;
   return null;
 }

--- a/client/src/hooks/useBillboard.ts
+++ b/client/src/hooks/useBillboard.ts
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { useThree, useFrame } from "@react-three/fiber";
-import { Object3D, Matrix4, Quaternion, Euler } from "three";
+import { Matrix4, Quaternion, Euler, Object3D } from "three";
 
 interface LockConfig {
   lockElevation?: boolean;
@@ -11,7 +11,7 @@ const _matrix = new Matrix4();
 const _euler = new Euler(0, 0, 0, "YXZ");
 const _quaternion = new Quaternion();
 
-function getAzimuth(quaternion) {
+function getAzimuth(quaternion: Quaternion) {
   _matrix.makeRotationFromQuaternion(quaternion);
   const elem = _matrix.elements;
   const m11 = elem[0],
@@ -25,8 +25,8 @@ function getAzimuth(quaternion) {
   else return Math.atan2(-m31, m11);
 }
 
-export function useBillboard({ lockElevation = false, follow = true }: LockConfig = {}) {
-  const objectRef = useRef<Object3D>();
+export function useBillboard<T>({ lockElevation = false, follow = true }: LockConfig = {}) {
+  const objectRef = useRef<T>(null) as React.RefObject<Object3D<Event>>;
   const { camera } = useThree();
 
   useFrame(() => {
@@ -47,5 +47,5 @@ export function useBillboard({ lockElevation = false, follow = true }: LockConfi
     }
   });
 
-  return objectRef;
+  return objectRef as React.RefObject<T>;
 }

--- a/client/src/hooks/useLoggedIn.ts
+++ b/client/src/hooks/useLoggedIn.ts
@@ -25,9 +25,11 @@ interface ICheck {
   id: string;
 }
 
-export function CheckLoggedIn({ resource }: { resource: Resource }) {
+export function CheckLoggedIn({ resource }: { resource: Resource<ICheck> }) {
   const { setUser, clearUser } = userStore();
-  const { logined, id: user } = useMemo(() => resource.read({ method: "get", url: "/auth/check" }) as ICheck, []);
+  const res = useMemo(() => resource.read({ method: "get", url: "/auth/check" }), []);
+  if (!res.data || res.error) return null;
+  const { logined, id: user } = res.data;
 
   useEffect(() => {
     if (logined) {

--- a/client/src/hooks/useResource.ts
+++ b/client/src/hooks/useResource.ts
@@ -9,7 +9,8 @@ export default function useResource<T>(
 ) {
   const data = useMemo(() => {
     const res = resource.read(options);
-    callback(res);
+    if (!res.data || res.error) return res;
+    callback(res.data);
     return res;
   }, []);
 

--- a/client/src/utils/suspender.ts
+++ b/client/src/utils/suspender.ts
@@ -1,17 +1,27 @@
-import axios, { AxiosRequestConfig } from "axios";
+import axios, { AxiosError, AxiosRequestConfig } from "axios";
 
-export type Resource<T = unknown> = { read: (config: AxiosRequestConfig) => T };
+export type Resource<T = unknown> = {
+  read: (config: AxiosRequestConfig) => { error: Error | AxiosError | null; data: T | null };
+};
 
 export function createResource<T>(options?: AxiosRequestConfig): Resource<T> {
   let data: T | null = null;
-  const suspender = (config: AxiosRequestConfig) => axios({ ...config, ...options }).then((res) => (data = res.data));
+  let error: Error | AxiosError | null = null;
+  const suspender = (config: AxiosRequestConfig) =>
+    axios({ ...config, ...options })
+      .then((res) => (data = res.data))
+      .catch((e: Error | AxiosError) => {
+        error = e;
+      });
 
   return {
     read(config: AxiosRequestConfig) {
-      if (data === null) {
+      if (data === null && !error) {
         throw suspender(config);
+      } else if (error) {
+        return { error, data };
       } else {
-        return data;
+        return { error, data };
       }
     },
   };


### PR DESCRIPTION
## Summary
useBillboard 및 useRef관련 타입에러 해결, suspender 에러처리 관련로직 추가

## Context
일단은 useBillboard훅에 재네릭을 추가하여 다음과 같이 작성하긴 했는데, as 를 이용하여 타입을 강제로 변경한 로직이므로 내부의 동작에 대한 타입에러를 보장할 수 없습니다.

이에 맞추어 useBillboard를 사용하는 다른 ref에 Mesh, Group 등 타입을 추가해 주어서 해결하였습니다.
```javascript
export function useBillboard<T>({ lockElevation = false, follow = true }: LockConfig = {}) {
  const objectRef = useRef<T>(null) as React.RefObject<Object3D<Event>>;
  // ...
  return objectRef as React.RefObject<T>;
}


```
suspense 관련해서 이전에는 에러가 발생한 요청도 계속 보내는 버그가 있었습니다. ( 아마 이미 아시는 분도 계실 것으로 예상함 )
![스크린샷 2022-11-23 오전 11 15 17](https://user-images.githubusercontent.com/68687144/203457305-d8428424-1623-4917-b057-c489b1fd1f5b.png)
위와 같이 에러가 발생해도 무한루프에 빠지며 계속 요청을 시도함

이를 해결하여 이제 에러가 발생하면 error를 response body에 포함시켜서 반환하며 더이상 요청을 다시보내지 않습니다. 따라서 결과값을 받는 부분에서 에러처리를 해줄 수 있는 인터페이스도 마련이 되었습니다.

```javascript
function Data({ resource }: { resource: Resource | null }) {
  const res = resource?.read({ method: "get", url: "/test/getData" });
  if (!res || res?.error) return <>에러가 발생했습니다.</>;
  window.location.href = `/gallery/${v4()}/${v4()}`;
  return null;
}
```

## Description
현재는 에러가 발생하면 요청을 중단하고 리턴하게 되지만 (다시 요청하면 에러가 발생하지 않음에도 불구하고 aka. 네트워크 에러) 요청횟수를 default값과 함께 파라미터로 넘겨주어 몇 번의 기회를 더 줄 수 있도록 구현할 생각입니다.