### PR TITLE
refactor: useDistanceEvent 훅 분리

### DIFF
--- a/client/src/GalleryPage/mapObjects/AnimatedTitle.tsx
+++ b/client/src/GalleryPage/mapObjects/AnimatedTitle.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from "react";
-import { useFrame, useThree } from "@react-three/fiber";
 import { Text } from "@react-three/drei";
 import { animated, Interpolation, useSpring } from "@react-spring/three";
 
 import Balloon from "./Balloon";
 import { useBillboard } from "../../hooks/useBillboard";
+import { useDistanceEvent } from "../../hooks/useDistanceEvent";
 
 import MapoFlowerIsland from "../../assets/fonts/MapoFlowerIsland.otf";
 import { generateRandomPastelColors } from "../../utils/random";
@@ -18,7 +18,6 @@ interface AnimatedTitleProps {
 export default function AnimatedTitle({ position, text }: AnimatedTitleProps) {
   const [active, setActive] = useState(0);
   const [action, setAction] = useState(false);
-  const { camera } = useThree();
   const textGroupRef = useBillboard<THREE.Group>({ follow: !action });
 
   const { spring } = useSpring({
@@ -36,16 +35,10 @@ export default function AnimatedTitle({ position, text }: AnimatedTitleProps) {
   const color: Interpolation<number, COLORS> = spring.to([0, 1], [COLORS.SKY400, COLORS[randomColors]]);
   const rotation = spring.to([0, 1], [0, Math.PI * 4]);
 
-  useFrame(() => {
-    const { x, z: y } = camera.position;
-
-    const distance = Math.abs(x - position[0]) + Math.abs(y - position[2]);
-
-    if (distance < 15) {
-      if (!active) setActive(+!active);
-    } else {
-      if (active) setActive(+!active);
-    }
+  useDistanceEvent({
+    area: { type: "circle", x: position[0], z: position[2], radius: 15 },
+    enterEvent: () => setActive(1),
+    exitEvent: () => setActive(0),
   });
 
   return (

--- a/client/src/hooks/useDistanceEvent.ts
+++ b/client/src/hooks/useDistanceEvent.ts
@@ -1,0 +1,62 @@
+import { Object3D } from "three";
+import { useState, useEffect } from "react";
+import { useThree, useFrame } from "@react-three/fiber";
+
+interface Rectangle {
+  type: "rect";
+  x: number;
+  z: number;
+  width: number;
+  height: number;
+}
+
+interface Circle {
+  type: "circle";
+  x: number;
+  z: number;
+  radius: number;
+}
+
+interface DistanceEventProps {
+  area: Rectangle | Circle;
+  enterEvent?: () => void;
+  exitEvent?: () => void;
+  target?: Object3D;
+}
+
+function checkPointAreaIntersect(point: { x: number; z: number }, area: Rectangle | Circle): boolean {
+  if (area.type === "circle") {
+    return Math.hypot(area.x - point.x, area.z - point.z) <= area.radius;
+  }
+  if (area.type === "rect") {
+    const between = (value: number, min: number, max: number) => min <= value && value <= max;
+    return (
+      between(point.x, area.x - area.width / 2, area.x + area.width / 2) &&
+      between(point.z, area.z - area.height / 2, area.z + area.height / 2)
+    );
+  }
+  throw new TypeError("area가 원형이나 사각형이 아닙니다!");
+}
+
+export function useDistanceEvent({ area, enterEvent, exitEvent, target }: DistanceEventProps) {
+  function getTarget(): Object3D {
+    if (target) return target;
+    const { camera } = useThree();
+    return camera;
+  }
+
+  const targetPointer = getTarget();
+  const { x, z } = targetPointer.position;
+  const [isInside, setInside] = useState<boolean>(checkPointAreaIntersect({ x, z }, area));
+
+  useEffect(() => {
+    if (isInside && enterEvent) enterEvent();
+    else if (!isInside && exitEvent) exitEvent();
+  }, [isInside]);
+
+  useFrame(() => {
+    const { x, z } = targetPointer.position;
+    const intersected = checkPointAreaIntersect({ x, z }, area);
+    if (isInside !== intersected) setInside(intersected);
+  });
+}


### PR DESCRIPTION
## Summary
useDistanceEvent 훅을 분리해서 플레이어가 해당 영역에 접근하면 발생하는 인터랙션을 더 용이하게 만들었습니다.

## Context
플레이어가 영역에 접근하면 발생하는 이벤트와 접근을 해제하는 발생하는 이벤트는 빈번하게 발생합니다. 이에 해당 훅을 분리하여 영역 접근 및 나가기 이벤트를 발생하기 쉽게 만들었습니다.

## Description
- useDistanceEvent 훅 분리
- 해당 부분을 사용하는 AnimationTitle에 훅 적용