### PR TITLE
fix: 각 페이지 부제목 type을 hType으로 이름 변경

### DIFF
--- a/client/src/@types/gallery.ts
+++ b/client/src/@types/gallery.ts
@@ -4,7 +4,7 @@ export interface IKeywordMap {
 
 export interface IGalleryPageSubTitle {
   text: string;
-  type: "h1" | "h2" | "h3";
+  hType: "h1" | "h2" | "h3";
 }
 
 export interface IGalleryPageLink {

--- a/client/src/GalleryPage/mapObjects/MemorialStone.tsx
+++ b/client/src/GalleryPage/mapObjects/MemorialStone.tsx
@@ -35,9 +35,9 @@ function calculateMemorialStonePosition(subtitles: IGalleryPageSubTitle[]) {
   ];
   let cursor = 0;
   const stoneInfoList: IStoneInfo[] = [];
-  const h1List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h1");
-  const h2List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h2");
-  const h3List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.type === "h3");
+  const h1List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.hType === "h1");
+  const h2List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.hType === "h2");
+  const h3List = subtitles.filter((subTitle: IGalleryPageSubTitle) => subTitle.hType === "h3");
   while (cursor < enalblePositions.length) {
     if (h1List.length > 0) {
       const subtitle = h1List.pop();
@@ -113,8 +113,8 @@ function getStyleByTitleType(type: string) {
 }
 
 function MemorialStone({ subTitle, position }: MemorialStoneProps) {
-  const { text, type } = subTitle;
-  const { textSize, stoneColor } = getStyleByTitleType(type);
+  const { text, hType } = subTitle;
+  const { textSize, stoneColor } = getStyleByTitleType(hType);
   const [pText, setPText] = useState("");
 
   const { visibleLetters, invisibleLetters } = useMemo(() => {

--- a/server/model/gallerySchema.js
+++ b/server/model/gallerySchema.js
@@ -10,8 +10,8 @@ const gallerySchema = new Schema({
   pages: [
     {
       position: [Number],
-      keywords: { type: Map, of: Number, default: "-" },
-      title: { type: String, required: true },
+      keywords: { type: Map, of: Number, required: true },
+      title: { type: String, default: "-" },
       subTitle: [
         {
           hType: String,

--- a/server/schema/gallerySchema.js
+++ b/server/schema/gallerySchema.js
@@ -10,8 +10,8 @@ const gallerySchema = new Schema({
   pages: [
     {
       position: [Number],
-      keywords: { type: Map, of: Number, default: "-" },
-      title: { type: String, required: true },
+      keywords: { type: Map, of: Number, required: true },
+      title: { type: String, default: "-" },
       subtitle: [
         {
           hType: String,

--- a/server/service/dataProcessService.js
+++ b/server/service/dataProcessService.js
@@ -25,19 +25,19 @@ function attachAllData(rawContent, notionKeyword, theme, positions, nodes) {
         subtitle: [
           ...notionKeyword.ppPages[page.id].h1_keywords.map((keyword) => {
             return {
-              type: "h1",
+              hType: "h1",
               text: keyword,
             };
           }),
           ...notionKeyword.ppPages[page.id].h2_keywords.map((keyword) => {
             return {
-              type: "h2",
+              hType: "h2",
               text: keyword,
             };
           }),
           ...notionKeyword.ppPages[page.id].h3_keywords.map((keyword) => {
             return {
-              type: "h3",
+              hType: "h3",
               text: keyword,
             };
           }),


### PR DESCRIPTION
## Summery
각 페이지 부제목 type을 hType으로 변경했습니다.
## Context
MongoDB 스키마의 type은 예약어이므로 key값으로 쓸 수 없습니다. 따라서 해당 부분을 피하고자 type으로 정의된 부제목의 타입을 hType으로 변경했습니다.