### PR TITLE
refactor:10자 미만의 소제목의 경우 애니메이션 비활성화

### DIFF
--- a/client/src/GalleryPage/dummyData.ts
+++ b/client/src/GalleryPage/dummyData.ts
@@ -18,11 +18,23 @@ const dummyData: IGalleryMapData = {
       title: "이것은 타이틀이다",
       subtitle: [
         { text: "이것은 h1타이틀", hType: "h1" },
-        { text: "이것도 h1타이틀", hType: "h1" },
-        { text: "쏜애플 사랑해요", hType: "h2" },
+        { text: "긴 제목은 흘러내립니다", hType: "h1" },
+        { text: "쏜애플 사랑해요요요", hType: "h2" },
         {
           text: "가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ",
           hType: "h2",
+        },
+        {
+          text: "별빛바다",
+          hType: "h2",
+        },
+        {
+          text: "기억",
+          hType: "h2",
+        },
+        {
+          text: "별",
+          hType: "h3",
         },
       ],
       keywords: {

--- a/client/src/GalleryPage/mapObjects/MemorialStone.tsx
+++ b/client/src/GalleryPage/mapObjects/MemorialStone.tsx
@@ -82,9 +82,9 @@ function textPreProcessing(text: string) {
   const letters = text.split("");
   let visibleLetters: string[] = [];
   let invisibleLetters: string[] = [];
-  if (letters.length > 20) {
-    visibleLetters = letters.slice(0, 20);
-    invisibleLetters = letters.slice(20);
+  if (letters.length > 10) {
+    visibleLetters = letters.slice(0, 10);
+    invisibleLetters = letters.slice(10);
   } else {
     visibleLetters = letters;
   }
@@ -95,15 +95,15 @@ function getStyleByTitleType(type: string) {
   let stoneColor = "";
   switch (type) {
     case "h1":
-      textSize = 1;
+      textSize = 0.6;
       stoneColor = COLORS.BROWN200;
       break;
     case "h2":
-      textSize = 0.7;
+      textSize = 0.4;
       stoneColor = COLORS.BROWN100;
       break;
     case "h3":
-      textSize = 0.5;
+      textSize = 0.3;
       stoneColor = COLORS.BROWN50;
       break;
     default:
@@ -127,41 +127,36 @@ function MemorialStone({ subTitle, position }: MemorialStoneProps) {
   const subtitleRef = useRef<Object3D>(null);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      if (!subtitleRef.current) return;
-      subtitleRef.current.position.y -= 1;
-      if (subtitleRef.current.position.y < 0) {
-        if (invisibleLetters.length > 0) {
-          const letter = visibleLetters.pop();
-          if (letter) {
-            invisibleLetters.push(letter);
-          }
-          const newLetter = invisibleLetters.shift();
-          if (newLetter) {
-            visibleLetters.unshift(newLetter);
-          }
-        } else {
-          const letter = visibleLetters.pop();
-          if (letter) {
-            visibleLetters.unshift(letter);
-          }
+    const needAnimation = invisibleLetters.length > 0 ? true : false;
+    let animation: ReturnType<typeof setInterval>;
+    if (needAnimation) {
+      animation = setInterval(() => {
+        if (!subtitleRef.current) return;
+        const letter = visibleLetters.pop();
+        if (letter) {
+          invisibleLetters.push(letter);
+        }
+        const newLetter = invisibleLetters.shift();
+        if (newLetter) {
+          visibleLetters.unshift(newLetter);
         }
         setPText(visibleLetters.join(" "));
-        subtitleRef.current.position.y = 0;
-      }
-    }, 300);
+      }, 300);
+    }
     return () => {
-      clearInterval(interval);
+      if (needAnimation) {
+        clearInterval(animation);
+      }
     };
   }, []);
   return (
     <group position={[position[0], 0, position[1]]} scale={textSize}>
       <Pedestal scale={0.5} color={stoneColor} />
-      <mesh ref={subtitleMeshRef} position-y={2}>
+      <mesh ref={subtitleMeshRef} position-y={textSize * (visibleLetters.length / 2) + 0.5}>
         <Text
           ref={subtitleRef}
           font={MapoFont}
-          fontSize={textSize * 0.7}
+          fontSize={textSize}
           color={"black"}
           maxWidth={0.1}
           textAlign={"center"}


### PR DESCRIPTION
## Summary
10자 미만의 소제목의 경우 애니메이션 비활성화
## Context
소제목들이 글자수에 상관없이 모두 흘러내리는 애니메이션이 적용되어 있는데, 짧은 소제목의 경우 이 애니메이션이 불필요하다고 판단함.
## Description
소제목의 글자들은 visibleLetters(지금 화면에 보여줄 글자), invisibleLetters(화면에 보이지 않을 글자)로 나뉘는데,
invisibleLetters가 빈배열이라면 애니메이션 비활성화 (setInterval X)
## 관련 이슈
- #73 