### PR TITLE
Feat: imagepixel

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -47,8 +47,8 @@ jobs:
             docker tag ${{secrets.DOCKER_USERNAME}}/express-server express-server
             docker tag ${{secrets.DOCKER_USERNAME}}/fastapi-server fastapi-server
             cd ~/proxy
-            curl -o docker-compose.yaml https://raw.githubusercontent.com/boostcampwm-2022/Web10-MonumentGallery/feat/https/docker-compose.yaml
-            curl -o nginx.conf https://raw.githubusercontent.com/boostcampwm-2022/Web10-MonumentGallery/feat/https/proxy/nginx.conf
+            curl -o docker-compose.yaml https://raw.githubusercontent.com/boostcampwm-2022/Web10-MonumentGallery/dev/docker-compose.yaml
+            curl -o nginx.conf https://raw.githubusercontent.com/boostcampwm-2022/Web10-MonumentGallery/dev/proxy/nginx.conf
             docker-compose stop
             docker rm express
             docker rm fastapi

--- a/python/main.py
+++ b/python/main.py
@@ -82,10 +82,13 @@ def preprocess_text(notionData:NotionData):
 @app.post("/preprocess/image")
 def preprocess_image(imgUrlData:ImageURLData):    
     img = Image.open(io.BytesIO(request.urlopen(imgUrlData.url).read()))
-    resized_img = img.resize((10, 10))
+    resized_img = img.resize((imgUrlData.width, imgUrlData.height))
     converted_img = resized_img.convert("RGB")
     pixels = list(converted_img.getdata())
-    hex_pixels = [ rgb_to_hex(pixel) for pixel in pixels ] 
+    hex_pixels = []
+
+    for i in range(0,imgUrlData.height):
+        hex_pixels.append([ rgb_to_hex(pixel) for pixel in pixels[imgUrlData.width * i : imgUrlData.width * (i+1) ] ] )
     return hex_pixels
 
 def rgb_to_hex(rgb):

--- a/python/model.py
+++ b/python/model.py
@@ -24,6 +24,8 @@ class preprocessedNotionData(BaseModel):
 
 class ImageURLData(BaseModel):
     url: str
+    width : int = 10,
+    height : int = 10,
 
 
 

--- a/server/router/galleryRouter.js
+++ b/server/router/galleryRouter.js
@@ -11,6 +11,7 @@ import {
   getLastGalleryID,
 } from "../service/dataSaveService.js";
 import { asyncHandler } from "../utils/utils.js";
+import { getImagePixelsFromPages } from "../service/imageProcessService.js";
 
 const router = express.Router();
 
@@ -19,14 +20,19 @@ router.post(
   authMiddleware,
   catchAuthError,
   asyncHandler(async (req, res) => {
+    //timeout 5분..
+    req.connection.setTimeout(60 * 5 * 1000);
     //duration= 2w||1m||3m||1y
+    console.log("page making start");
     const userID = req.userid;
     const notionAccessToken = req.accessToken;
     const nowTime = Date.now();
     const { period = "all", theme = "dream" } = req.query;
 
     const notionRawContent = await getRawContentsFromNotion(notionAccessToken, period);
-    const processedNotionContent = await processDataFromRawContent(notionRawContent, theme);
+    const notionImageContent = await getImagePixelsFromPages(notionRawContent);
+    // console.log(notionImageContent);
+    const processedNotionContent = await processDataFromRawContent(notionImageContent, theme);
     const galleryID = await saveGallery(userID, processedNotionContent);
 
     console.log(`총 처리 시간: ${Date.now() - nowTime}`);

--- a/server/router/testRouter.js
+++ b/server/router/testRouter.js
@@ -5,6 +5,7 @@ import { getRawContentsFromNotion } from "../service/getNotionContentService.js"
 import galleryMockData from "../model/galleryDummyData.js";
 import { processDataFromRawContent } from "../service/dataProcessService.js";
 import Gallery from "../schema/gallerySchema.js";
+import { getImagePixelsFromPages } from "../service/imageProcessService.js";
 
 const router = express.Router();
 
@@ -42,19 +43,21 @@ router.get("/getData", async (req, res) => {
   const { period = "all", theme = "dream" } = req.query;
 
   const notionRawContent = await getRawContentsFromNotion(notionAccessToken, period);
-  console.log(notionRawContent);
-  const processedNotionContent = await processDataFromRawContent(notionRawContent, theme);
-  console.log(processedNotionContent);
-  console.log(processedNotionContent.pages);
+  // console.log(notionRawContent);
+  const notionContentImage = await getImagePixelsFromPages(notionRawContent);
+  console.log(notionContentImage);
+  const processedNotionContent = await processDataFromRawContent(notionContentImage, theme);
+  // console.log(processedNotionContent);
+  // console.log(processedNotionContent.pages);
 
-  await Gallery.create(processedNotionContent)
-    .then((e) => {
-      console.log("success");
-    })
-    .catch((err) => {
-      console.log(err);
-      console.log("failed");
-    });
+  // await Gallery.create(processedNotionContent)
+  //   .then((e) => {
+  //     console.log("success");
+  //   })
+  //   .catch((err) => {
+  //     console.log(err);
+  //     console.log("failed");
+  //   });
 
   const allData = await Gallery.find();
   console.log(allData);
@@ -188,5 +191,7 @@ const mockData = {
 };
 
 const mockImageUrlData = {
-  url: "https://grigostore.shop/file_data/grigostore/2021/09/22/29a2131b07160b2413021277862c2259.png",
+  url: "https://img.animalplanet.co.kr/news/2019/08/10/700/v4q0b0ff4hcpew1g6t39.jpg",
+  width: 10,
+  height: 10,
 };

--- a/server/schema/gallerySchema.js
+++ b/server/schema/gallerySchema.js
@@ -8,6 +8,12 @@ const keywordScheama = new Schema({
 const gallerySchema = new Schema({
   theme: { type: String, required: true },
   totalKeywords: [keywordScheama],
+  groupKeywords: [
+    {
+      node: { type: Number, required: true },
+      keyword: { type: String, default: "-" },
+    },
+  ],
   pages: [
     {
       position: [Number],
@@ -25,9 +31,13 @@ const gallerySchema = new Schema({
           favicon: String,
         },
       ],
+      imagePixel: [[String]],
+      myUrl: { type: String, required: true },
     },
   ],
   nodes: [[Number]],
+  lastModified: { type: Date, default: new Date() },
+  created: { type: Date, default: new Date() },
 });
 
 export default model("monument_gallery_dev_lybell", gallerySchema);

--- a/server/service/dataProcessService.js
+++ b/server/service/dataProcessService.js
@@ -34,6 +34,7 @@ export function processDataForClient(galleryContent) {
         subtitle: page.subtitle,
         links: page.links,
         imagePixel: page.imagePixel,
+        myUrl: page.myUrl,
       };
     }),
     nodes: galleryContent.nodes,
@@ -72,6 +73,7 @@ function attachAllDataForDB(rawContent, notionKeyword, theme, positions, nodes, 
         ],
         links: rawContent[page.id].links,
         imagePixel: rawContent[page.id].imagePixel,
+        myUrl: rawContent[page.id].myUrl,
       };
     }),
     nodes,

--- a/server/service/dataProcessService.js
+++ b/server/service/dataProcessService.js
@@ -9,16 +9,7 @@ export async function processDataFromRawContent(rawContent, theme) {
   const positionData = getPositions(grouppedPage);
   // console.log(positionData.pages);
   // console.log(positionData.nodes);
-  const res = attachAllDataForDB(rawContent, keywordData, theme, positionData.pages, positionData.nodes);
-
-  return attachAllDataForDB(
-    rawContent,
-    keywordData,
-    theme,
-    positionData.pages,
-    positionData.nodes,
-    positionData.groupKeywords,
-  );
+  return attachAllDataForDB(rawContent, keywordData, theme, positionData);
 }
 
 export function processDataForClient(galleryContent) {
@@ -41,12 +32,12 @@ export function processDataForClient(galleryContent) {
   };
 }
 
-function attachAllDataForDB(rawContent, notionKeyword, theme, positions, nodes, groupKeywords) {
+function attachAllDataForDB(rawContent, notionKeyword, theme, positionData) {
   return {
     theme: theme,
     totalKeywords: getTop30Keywords(notionKeyword.totalKeywords),
-    groupKeywords,
-    pages: positions.map((page) => {
+    groupKeywords: positionData.groupKeywords,
+    pages: positionData.pages.map((page) => {
       return {
         position: page.position,
         keywords: getTop30Keywords(notionKeyword.ppPages[page.id].keywords),
@@ -76,7 +67,7 @@ function attachAllDataForDB(rawContent, notionKeyword, theme, positions, nodes, 
         myUrl: rawContent[page.id].myUrl,
       };
     }),
-    nodes,
+    nodes: positionData.nodes,
   };
 }
 

--- a/server/service/dataProcessService.js
+++ b/server/service/dataProcessService.js
@@ -4,11 +4,11 @@ import axios from "axios";
 export async function processDataFromRawContent(rawContent, theme) {
   const keywordData = await getKeywordFromFastAPI(rawContent);
   const grouppedPage = getGroups(keywordData);
-  console.log("keywords : ", keywordData);
-  console.log("groupPage : ", grouppedPage);
+  // console.log("keywords : ", keywordData);
+  // console.log("groupPage : ", grouppedPage);
   const positionData = getPositions(grouppedPage);
-  console.log(positionData.pages);
-  console.log(positionData.nodes);
+  // console.log(positionData.pages);
+  // console.log(positionData.nodes);
   const res = attachAllDataForDB(rawContent, keywordData, theme, positionData.pages, positionData.nodes);
 
   return attachAllDataForDB(rawContent, keywordData, theme, positionData.pages, positionData.nodes);
@@ -25,6 +25,7 @@ export function processDataForClient(galleryContent) {
         title: page.title,
         subtitle: page.subtitle,
         links: page.links,
+        imagePixel: page.imagePixel,
       };
     }),
     nodes: galleryContent.nodes,
@@ -61,6 +62,7 @@ function attachAllDataForDB(rawContent, notionKeyword, theme, positions, nodes) 
           }),
         ],
         links: rawContent[page.id].links,
+        imagePixel: rawContent[page.id].imagePixel,
       };
     }),
     nodes,
@@ -119,7 +121,7 @@ function getFastAPIFormData(rawContent) {
   //data를 fastapi 서버로 보내기 용이한 형태로 가공
   return Object.keys(rawContent).reduce(
     (acc, cur) => {
-      console.log(cur);
+      // console.log(cur);
       acc.pages[cur] = {
         title: rawContent[cur].title,
         h1: rawContent[cur].h1,
@@ -135,7 +137,7 @@ function getFastAPIFormData(rawContent) {
 
 function getGroups(keywords) {
   const sortedTotalKeywords = sortKeywords(keywords.totalKeywords);
-  console.log(sortedTotalKeywords);
+  // console.log(sortedTotalKeywords);
 
   if (sortedTotalKeywords.length < 3) return {};
 

--- a/server/service/dataProcessService.js
+++ b/server/service/dataProcessService.js
@@ -11,13 +11,21 @@ export async function processDataFromRawContent(rawContent, theme) {
   // console.log(positionData.nodes);
   const res = attachAllDataForDB(rawContent, keywordData, theme, positionData.pages, positionData.nodes);
 
-  return attachAllDataForDB(rawContent, keywordData, theme, positionData.pages, positionData.nodes);
+  return attachAllDataForDB(
+    rawContent,
+    keywordData,
+    theme,
+    positionData.pages,
+    positionData.nodes,
+    positionData.groupKeywords,
+  );
 }
 
 export function processDataForClient(galleryContent) {
   return {
     theme: galleryContent.theme,
     totalKeywords: getKeywordsAsDictionary(galleryContent.totalKeywords),
+    groupKeywords: galleryContent.groupKeywords,
     pages: galleryContent.pages.map((page) => {
       return {
         position: page.position,
@@ -32,10 +40,11 @@ export function processDataForClient(galleryContent) {
   };
 }
 
-function attachAllDataForDB(rawContent, notionKeyword, theme, positions, nodes) {
+function attachAllDataForDB(rawContent, notionKeyword, theme, positions, nodes, groupKeywords) {
   return {
     theme: theme,
     totalKeywords: getTop30Keywords(notionKeyword.totalKeywords),
+    groupKeywords,
     pages: positions.map((page) => {
       return {
         position: page.position,
@@ -173,17 +182,20 @@ function getPositions(groups) {
   //중심 좌표 (0,0)
   let pages = [];
   let nodes = [];
+  let groupKeywords = [];
 
   Object.keys(groups).forEach((keyword, idx) => {
     const nowPositionData = getSquarePositions(groups[keyword], idx, pages.length);
-    console.log(nowPositionData.pages, nowPositionData.nodes);
+    // console.log(nowPositionData.pages, nowPositionData.nodes);
+    groupKeywords = [...groupKeywords, ...[{ keyword: keyword, node: pages.length }]];
     pages = [...pages, ...nowPositionData.pages];
     nodes = [...nodes, ...nowPositionData.nodes];
   });
-
+  // console.log(groupKeywords);
   return {
     pages,
     nodes,
+    groupKeywords: groupKeywords,
   };
 }
 

--- a/server/service/dataSaveService.js
+++ b/server/service/dataSaveService.js
@@ -18,6 +18,7 @@ function validateGalleryID(galleryID) {
 export async function saveGallery(userID, galleryData) {
   const id = await saveGalleryFromDB(userID, galleryData);
   if (id === null) throw new InternalServerError("DB 저장 실패");
+  console.log("db저장 완료");
   return id;
 }
 

--- a/server/service/imageProcessService.js
+++ b/server/service/imageProcessService.js
@@ -1,0 +1,160 @@
+import axios from "axios";
+
+export async function getImagePixelsFromPages(pages, width = 10, height = 10) {
+  //기본은 10x10으로 하되, 매개변수에 따라 달라짐
+  const res = await Promise.all(
+    Object.keys(pages).map(async (pageId) => {
+      return {
+        ...pages[pageId],
+        imagePixel: await getImagePixelsFromFastAPI(pages[pageId], width, height),
+      };
+    }),
+  );
+  return res;
+}
+
+async function getImagePixelsFromFastAPI(page, width, height) {
+  const fastapiEndpoint = process.env.FASTAPI_ENDPOINT;
+  if (page.image.length <= 0) return mockData;
+  const imageURL = page.image[0];
+  //   console.log(imageURL);
+  const imagePixels = await axios
+    .post(fastapiEndpoint + "/preprocess/image", {
+      url: imageURL,
+      width: width,
+      height: height,
+    })
+    .then((e) => {
+      //   console.log(e);
+      //   console.log(e.data);
+      return e.data;
+    })
+    .catch((err) => {
+      console.log(imageURL, "이미지 처리 에러");
+      return mockData;
+    });
+  return imagePixels;
+}
+
+const mockData = [
+  [
+    "0xe2ebf7",
+    "0xd0dff4",
+    "0xb6cff0",
+    "0xb3cdf0",
+    "0x9dbee7",
+    "0x8fb7e6",
+    "0x8db7e7",
+    "0x8cb5e4",
+    "0x92b6e5",
+    "0xa3bde6",
+  ],
+  [
+    "0xf6f6f9",
+    "0xf7f8f8",
+    "0xe1e8f6",
+    "0xeaeef9",
+    "0xb6b0c5",
+    "0x898fac",
+    "0x9bb3d6",
+    "0x9ebee7",
+    "0xb0c6e9",
+    "0xc8d3eb",
+  ],
+  [
+    "0xe7eaf8",
+    "0xebeef8",
+    "0xf4f6fa",
+    "0xeeedf3",
+    "0x8b7380",
+    "0x614a58",
+    "0x8b7983",
+    "0x96a4c4",
+    "0xc9d8f0",
+    "0xdee0ee",
+  ],
+  [
+    "0xe4ebf9",
+    "0xd9e7f7",
+    "0xcde4f9",
+    "0xbdc6db",
+    "0x60454f",
+    "0x4b2d30",
+    "0x876d6a",
+    "0xb7c4da",
+    "0xb7cfee",
+    "0xd2d8eb",
+  ],
+  [
+    "0xecf0f8",
+    "0xeff1f7",
+    "0xf1f5fb",
+    "0xc0bfcb",
+    "0x74575b",
+    "0x5a3838",
+    "0x785252",
+    "0xcac9d7",
+    "0xcfddf2",
+    "0xdde1ef",
+  ],
+  [
+    "0xdfecf9",
+    "0xe5ecf7",
+    "0xeef6fc",
+    "0xa89aa0",
+    "0x603b3b",
+    "0x67403d",
+    "0x754545",
+    "0xd7cdd6",
+    "0xe4e7f5",
+    "0xd9dcea",
+  ],
+  [
+    "0xedf1f9",
+    "0xe0eefb",
+    "0xd9efff",
+    "0xa89799",
+    "0x5c3a33",
+    "0x371d1e",
+    "0x805b5b",
+    "0xe1dfe9",
+    "0xdee0ef",
+    "0xd4d6e4",
+  ],
+  [
+    "0xeaeef9",
+    "0xecf1fb",
+    "0xd1dae5",
+    "0xb4958e",
+    "0xb28877",
+    "0x9c7365",
+    "0xc0b5b8",
+    "0xe0e9f7",
+    "0xd7dbeb",
+    "0xd1d5e6",
+  ],
+  [
+    "0xd5d9e0",
+    "0xebecf6",
+    "0xc3aba9",
+    "0xc39c8f",
+    "0xc6a296",
+    "0xcebebb",
+    "0xdde4f2",
+    "0xd7e2f2",
+    "0xdce3f4",
+    "0xdbe0f2",
+  ],
+  [
+    "0x86887a",
+    "0xc5b4b4",
+    "0xc39e91",
+    "0xcca592",
+    "0xd0b7af",
+    "0xe2e5ed",
+    "0xdee1ed",
+    "0xdaddec",
+    "0xdfe3f1",
+    "0xe0e3f2",
+  ],
+];


### PR DESCRIPTION
# Summary
이미지 픽셀 저장, 각 그룹별 키워드 저장, 페이지 내 url 저장
# Context
이미지 픽셀을 파편화 하고, 배치된 페이지들이 어떤 기준으로 그룹화 되어있는 지 알 수 있게 하고, 각 페이지 섬에서 해당하는 노션 페이지로 이동하기 위함
# Description
- 이미지 픽셀
  - 기존 Fastapi의 이미지 관련 로직이 일차원 배열을 반환하기 때문에, 추가로 width, height 값을 넘겨주어 이차원 배열로 반환하게 끔 로직 재구성,
  - default 값을 줄 수 있으면 좋겠는데 이 부분은 수정이 필요함
- 각 그룹별 키워드 저장
  - groupKeywords라는 키에 저장. 자세한 건 문서 참조
- 페이지 내 url 저장
  - pages 내에 myUrl이라는 키에 저장. 자세한 건 문서 참조

### 논의할 것
- 테스트하는 과정에서 동일한 api가 3번 이상씩 호출되는 현상 발견. express 자체 타임아웃을 늘려보았으나 실제로 적용되었는 지는 테스트 필요
- 이 밖에도 코드 리팩토링이 전반적으로 필요할 것으로 보임. 좀 더 분리해야 할 듯