### PR TITLE
Refactor/suspense

### DIFF
--- a/client/src/@types/gallery.ts
+++ b/client/src/@types/gallery.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from "axios";
+
 export interface IKeywordMap {
   [keyword: string]: number;
 }
@@ -55,3 +57,9 @@ export const THEME = {
   WINTER: "WINTER",
 } as const;
 export type THEME = typeof THEME[keyof typeof THEME];
+
+export type GalleryLoadErrorEvent = Event & {
+  detail?: AxiosError<GalleryLoadError>;
+};
+
+type GalleryLoadError = { reason: string };

--- a/client/src/GalleryPage/ErrorPage.tsx
+++ b/client/src/GalleryPage/ErrorPage.tsx
@@ -10,7 +10,7 @@ import Gallery from "./Gallery";
 export default function ErrorPage() {
   const { applyGallery } = useGalleryHistorySave();
   const [useSampleData, setUseSampleData] = useState(false);
-  const [remainTime, setRemainTime] = useState(50000);
+  const [remainTime, setRemainTime] = useState(5);
   const { addToast } = toastStore();
 
   useEffect(() => {

--- a/client/src/GalleryPage/ErrorPage.tsx
+++ b/client/src/GalleryPage/ErrorPage.tsx
@@ -1,0 +1,61 @@
+import { Suspense, useEffect, useState } from "react";
+import FullScreenModal from "../components/modal/FullScreenModal";
+import TOAST from "../components/Toast/ToastList";
+import { useGalleryHistorySave } from "../hooks/useGalleryHistorySave";
+import toastStore from "../store/toast.store";
+import Loading from "./components/Loading";
+import dummyData from "./dummyData";
+import Gallery from "./Gallery";
+
+export default function ErrorPage() {
+  const { applyGallery } = useGalleryHistorySave();
+  const [useSampleData, setUseSampleData] = useState(false);
+  const [remainTime, setRemainTime] = useState(50000);
+  const { addToast } = toastStore();
+
+  useEffect(() => {
+    if (!useSampleData) return;
+
+    applyGallery(dummyData, "");
+    addToast(TOAST.INFO("데이터가 존재하지 않아 샘플 월드를 랜더링합니다", 5000));
+    addToast(TOAST.INFO("WASD 키로 캐릭터를 움직입니다.", 1000 * 10));
+    addToast(TOAST.INFO("left shift 및 space로 상하움직임을 제어합니다.", 1000 * 10));
+    addToast(TOAST.INFO("E 키눌러 마우스로 화면전환을 할 수 있습니다.", 1000 * 10));
+    addToast(TOAST.INFO("E 키를 다시 눌러 마우스를 표시합니다.", 1000 * 10));
+  }, [useSampleData]);
+
+  useEffect(() => {
+    if (useSampleData) return;
+    if (remainTime <= 0) {
+      window.location.href = "/";
+    }
+    const timeout = setTimeout(() => {
+      setRemainTime(remainTime - 1);
+    }, 1000);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [remainTime, useSampleData]);
+
+  if (!useSampleData) {
+    return (
+      <div>
+        <Loading />
+        <FullScreenModal show={true} css={{ width: "50%", height: "30%" }}>
+          <div className="modal error-modal">
+            <span className="error-span">메인화면으로 돌아갑니다 ... {remainTime}</span>
+            <button className="enter-sample-world-button" onClick={() => setUseSampleData(true)}>
+              샘플 월드로 입장하기
+            </button>
+          </div>
+        </FullScreenModal>
+      </div>
+    );
+  }
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <Gallery />
+    </Suspense>
+  );
+}

--- a/client/src/GalleryPage/GalleryPage.tsx
+++ b/client/src/GalleryPage/GalleryPage.tsx
@@ -1,94 +1,69 @@
-import React, { Suspense, useEffect, useMemo, useState } from "react";
+import React, { Suspense, useEffect, useState } from "react";
 
 import Gallery from "./Gallery";
 import DomElements from "./components/DomElements";
 import Loading from "./components/Loading";
-import FullScreenModal from "../components/modal/FullScreenModal";
-import TOAST from "../components/Toast/ToastList";
 
 import { useParams } from "../hooks/useParams";
 import { useGalleryHistorySave } from "../hooks/useGalleryHistorySave";
-import toastStore from "../store/toast.store";
 
-import { createResource, Resource } from "../utils/suspender";
-
-import { IGalleryDataResponse } from "../@types/gallery";
-import dummyData from "./dummyData";
 import "./style.scss";
+import galleryStore from "../store/gallery.store";
+import ErrorBoundary from "../components/common/ErrorBoundary";
+import ErrorPage from "./ErrorPage";
+import toastStore from "../store/toast.store";
+import { GalleryLoadErrorEvent } from "../@types/gallery";
+import TOAST from "../components/Toast/ToastList";
 
 export default function GalleryPage() {
   const [user, history] = useParams("gallery", []);
-
-  const requestUrl = useMemo(() => getRequestUrl(), []);
-  const [resource, setResource] = useState({ method: "get", url: requestUrl });
+  const [requestUrl, setRequestUrl] = useState(getRequestUrl());
+  const { addToast } = toastStore();
 
   function getRequestUrl() {
     const END_POINT = "/api/gallery";
     return END_POINT + (user ? `/${user}` : ``) + (history ? `/${history}` : ``);
   }
+
+  useEffect(() => {
+    function errorHandler(e: GalleryLoadErrorEvent) {
+      if (!e.detail?.response) return;
+      const { reason } = e.detail.response.data;
+      addToast(TOAST.ERROR(reason));
+      console.log(reason);
+    }
+    document.addEventListener("error-reason", errorHandler);
+    () => document.removeEventListener("error-reason", errorHandler);
+  }, []);
+
   return (
-    <Suspense fallback={<Loading text="데이터를 가져오는 중입니다" />}>
+    <>
       <div className="canvas-outer">
-        <GalleryLoader resource={createResource(resource)} />
+        <ErrorBoundary fallback={<ErrorPage />}>
+          <Suspense fallback={<Loading text="데이터를 가져오는 중입니다" />}>
+            <GalleryLoader url={requestUrl} />
+          </Suspense>
+        </ErrorBoundary>
       </div>
-      <DomElements setResource={setResource} />
-    </Suspense>
+      <DomElements setRequestUrl={setRequestUrl} />
+    </>
   );
 }
 
-function GalleryLoader({ resource }: { resource: Resource<IGalleryDataResponse> }) {
-  const [remainTime, setRemainTime] = useState(5);
-  const [useSampleData, setUseSampleData] = useState(false);
+function GalleryLoader({ url }: { url: string }) {
   const [isInitialized, setInitialize] = useState(false);
   const { applyGallery, initializeGallery } = useGalleryHistorySave();
-  const { addToast, removeToast } = toastStore();
+  const { getData } = galleryStore();
 
-  const { data, error } = resource.read();
+  const data = getData(url);
 
-  // 데이터가 존재할 때 실제 데이터 적용
   useEffect(() => {
-    if (!data) return;
-
     const { gallery, userId, page } = data;
     if (!isInitialized) {
       initializeGallery(gallery, userId);
       setInitialize(true);
     } else applyGallery(gallery, userId, page);
   }, [data]);
-
-  // 데이터가 존재하지 않을 때 샘플 데이터 적용
-  useEffect(() => {
-    if (data || !useSampleData) return;
-
-    applyGallery(dummyData, "");
-    addToast(TOAST.INFO("데이터가 존재하지 않아 샘플 월드를 랜더링합니다", 5000));
-    addToast(TOAST.INFO("WASD 키로 캐릭터를 움직입니다.", 1000 * 10));
-    addToast(TOAST.INFO("left shift 및 space로 상하움직임을 제어합니다.", 1000 * 10));
-    addToast(TOAST.INFO("E 키눌러 마우스로 화면전환을 할 수 있습니다.", 1000 * 10));
-    addToast(TOAST.INFO("E 키를 다시 눌러 마우스를 표시합니다.", 1000 * 10));
-  }, [data === null && useSampleData]);
-
-  // 데이터를 불러오지 못했을 때 타임아웃 메시지 띄우기
-  useEffect(() => {
-    if (data || useSampleData) return;
-    if (remainTime <= 0) {
-      window.location.href = "/";
-    }
-    const timeout = setTimeout(() => {
-      setRemainTime(remainTime - 1);
-    }, 1000);
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [remainTime, useSampleData]);
-
-  // 데이터를 불러오지 못했을 때 에러 메시지 띄우기
-  useEffect(() => {
-    if (!error) return;
-    const errorToast = TOAST.ERROR(error.message);
-    addToast(errorToast);
-    return () => removeToast(errorToast);
-  }, [error]);
 
   // 뒤로가기, 앞으로가기 이벤트 바인딩
   useEffect(() => {
@@ -103,22 +78,6 @@ function GalleryLoader({ resource }: { resource: Resource<IGalleryDataResponse> 
       window.removeEventListener("popstate", popState);
     };
   }, []);
-
-  if (!data && !useSampleData) {
-    return (
-      <div>
-        <Loading />
-        <FullScreenModal show={true} css={{ width: "50%", height: "30%" }}>
-          <div className="modal error-modal">
-            <span className="error-span">메인화면으로 돌아갑니다 ... {remainTime}</span>
-            <button className="enter-sample-world-button" onClick={() => setUseSampleData(true)}>
-              샘플 월드로 입장하기
-            </button>
-          </div>
-        </FullScreenModal>
-      </div>
-    );
-  }
 
   return (
     <Suspense fallback={<Loading />}>

--- a/client/src/GalleryPage/components/DomElements.tsx
+++ b/client/src/GalleryPage/components/DomElements.tsx
@@ -21,14 +21,9 @@ import { IHistory } from "../../@types/gallery";
 import URLCopy from "../../utils/URLCopy";
 
 export default function DomElements({
-  setResource,
+  setRequestUrl,
 }: {
-  setResource: React.Dispatch<
-    React.SetStateAction<{
-      method: string;
-      url: string;
-    }>
-  >;
+  setRequestUrl: React.Dispatch<React.SetStateAction<string>>;
 }) {
   const { locked } = lockStore();
   const [showShareModal, setShowShareModal] = useState(false);
@@ -54,7 +49,7 @@ export default function DomElements({
         <FullScreenModal css={{ width: "400px", height: "230px" }} show={showShareModal} setShow={setShowShareModal}>
           <ShareModal onShareButtonClick={() => setShowShareModal(false)} />
         </FullScreenModal>
-        <HistorySidebar show={showSidebar} setShow={setShowSidebar} setResource={setResource} />
+        <HistorySidebar show={showSidebar} setShow={setShowSidebar} setRequestUrl={setRequestUrl} />
       </div>
       <Toast position="bottom-right" autoDelete={true} autoDeleteTime={2000} />
     </>
@@ -154,16 +149,11 @@ function ShareButton({ show, setShow }: { show: boolean; setShow: React.Dispatch
 function HistorySidebar({
   show,
   setShow,
-  setResource,
+  setRequestUrl,
 }: {
   show: boolean;
   setShow: React.Dispatch<React.SetStateAction<boolean>>;
-  setResource: React.Dispatch<
-    React.SetStateAction<{
-      method: string;
-      url: string;
-    }>
-  >;
+  setRequestUrl: React.Dispatch<React.SetStateAction<string>>;
 }) {
   const historyRef = useRef<HTMLDivElement>(null);
   const historyListRef = useRef<HTMLDivElement>(null);
@@ -220,7 +210,7 @@ function HistorySidebar({
   function setGalleryDataFromHistory() {
     const history = histories[selected];
     const url = `/api/gallery/${userId}/${history.id}`;
-    setResource({ method: "get", url });
+    setRequestUrl(url);
     setShow(false);
     setShowHistoryModal(false);
   }

--- a/client/src/MainPage/MainPage.tsx
+++ b/client/src/MainPage/MainPage.tsx
@@ -12,6 +12,7 @@ import userStore from "../store/user.store";
 
 import FloatLayout from "../layouts/FloatLayout";
 import "./style.scss";
+import testStore from "../store/test.store";
 
 export default function MainPage() {
   const [show, setShow] = useState<boolean>(false);
@@ -50,5 +51,16 @@ export default function MainPage() {
         <CreateModal />
       </FullScreenModal>
     </>
+  );
+}
+
+function Test() {
+  const { getTest } = testStore();
+  const data = getTest();
+
+  return (
+    <div>
+      <span>{JSON.stringify(data)}</span>
+    </div>
   );
 }

--- a/client/src/MainPage/MainPage.tsx
+++ b/client/src/MainPage/MainPage.tsx
@@ -12,7 +12,6 @@ import userStore from "../store/user.store";
 
 import FloatLayout from "../layouts/FloatLayout";
 import "./style.scss";
-import testStore from "../store/test.store";
 
 export default function MainPage() {
   const [show, setShow] = useState<boolean>(false);
@@ -51,16 +50,5 @@ export default function MainPage() {
         <CreateModal />
       </FullScreenModal>
     </>
-  );
-}
-
-function Test() {
-  const { getTest } = testStore();
-  const data = getTest();
-
-  return (
-    <div>
-      <span>{JSON.stringify(data)}</span>
-    </div>
   );
 }

--- a/client/src/components/common/ErrorBoundary.tsx
+++ b/client/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export default class ErrorBoundary extends React.Component {
+  state: React.ComponentState;
+  declare props: React.PropsWithChildren & { fallback?: React.ReactNode };
+
+  constructor(props: React.PropsWithChildren & { fallback?: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: unknown) {
+    return;
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}

--- a/client/src/hooks/useLoggedIn.ts
+++ b/client/src/hooks/useLoggedIn.ts
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import userStore from "../store/user.store";
-import { createResource } from "../utils/suspender";
 import { User } from "../@types/common";
 
 export interface ICheck {
@@ -10,13 +9,9 @@ export interface ICheck {
   isCreated: boolean;
 }
 
-const resource = createResource<ICheck>({ method: "get", url: "/auth/check" });
-
 export function CheckLoggedIn() {
-  const { setUser, setShared, setCreated, clearUser } = userStore();
-  const res = resource.read();
-  if (!res.data || res.error) return null;
-  const { logined, user, isShared, isCreated } = res.data;
+  const { getUser, setUser, setShared, setCreated, clearUser } = userStore();
+  const { logined, user, isShared, isCreated } = getUser();
 
   useEffect(() => {
     if (logined) {

--- a/client/src/store/gallery.store.ts
+++ b/client/src/store/gallery.store.ts
@@ -1,10 +1,12 @@
 import create from "zustand";
-import { IGalleryMapData, THEME } from "../@types/gallery";
+import { IGalleryDataResponse, IGalleryMapData, THEME } from "../@types/gallery";
+import { gallerySelector } from "./selectors";
 
 interface GalleryStore {
   data: IGalleryMapData;
   userId: string | null;
   theme: THEME | null;
+  getData: (url: string) => IGalleryDataResponse;
   setData: (gallery: IGalleryMapData, userId: string) => void;
   setTheme: (theme: THEME) => void;
 }
@@ -19,6 +21,7 @@ const galleryStore = create<GalleryStore>((set) => ({
   },
   userId: null,
   theme: THEME.DREAM,
+  getData: (url) => gallerySelector(url).data,
   setData: (data, userId) => set({ data, userId, theme: data.theme }),
   setTheme: (theme) => set({ theme }),
 }));

--- a/client/src/store/select.ts
+++ b/client/src/store/select.ts
@@ -24,7 +24,7 @@ const use = <T>(promise: Selector<T>): T => {
   } else if (promise.status === STATUS.REJECTED) {
     throw promise.reason;
   } else {
-    promise.status === STATUS.PENDING;
+    promise.status = STATUS.PENDING;
     promise.then(
       (val) => {
         promise.status = STATUS.FULFILLED;

--- a/client/src/store/select.ts
+++ b/client/src/store/select.ts
@@ -32,6 +32,7 @@ const use = <T>(promise: Selector<T>): T => {
       },
       (err) => {
         promise.status = STATUS.REJECTED;
+        document.dispatchEvent(new CustomEvent("error-reason", { detail: err }));
         promise.reason = err;
       },
     );

--- a/client/src/store/select.ts
+++ b/client/src/store/select.ts
@@ -1,0 +1,50 @@
+const STATUS = {
+  PENDING: "pending",
+  FULFILLED: "fulfilled",
+  REJECTED: "rejected",
+} as const;
+
+type STATUS = typeof STATUS[keyof typeof STATUS];
+
+type Selector<T> = Promise<T> & {
+  status?: STATUS;
+  value?: T;
+  reason?: unknown;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const selectors = new Map<string, Selector<any>>();
+
+const use = <T>(promise: Selector<T>): T => {
+  if (promise.status === STATUS.PENDING) {
+    throw promise;
+  } else if (promise.status === STATUS.FULFILLED) {
+    return promise.value as T;
+  } else if (promise.status === STATUS.REJECTED) {
+    throw promise.reason;
+  } else {
+    promise.status === STATUS.PENDING;
+    promise.then(
+      (val) => {
+        promise.status = STATUS.FULFILLED;
+        promise.value = val;
+      },
+      (err) => {
+        promise.status = STATUS.REJECTED;
+        promise.reason = err;
+      },
+    );
+    throw promise;
+  }
+};
+
+export const select = <T>({ key, get }: { key: string; get: () => Selector<T> }) => {
+  const selector = selectors.get(key);
+  if (selector) {
+    return use<T>(selector);
+  } else {
+    const newSelector = get();
+    selectors.set(key, newSelector);
+    return use<T>(newSelector);
+  }
+};

--- a/client/src/store/select.ts
+++ b/client/src/store/select.ts
@@ -15,6 +15,7 @@ type Selector<T> = Promise<T> & {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const selectors = new Map<string, Selector<any>>();
 
+// https://github.com/pmndrs/jotai/blob/main/src/react/useAtomValue.ts#L12
 const use = <T>(promise: Selector<T>): T => {
   if (promise.status === STATUS.PENDING) {
     throw promise;

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosResponse } from "axios";
+import { IGalleryDataResponse } from "../@types/gallery";
 import { ICheck } from "../hooks/useLoggedIn";
 import { select } from "./select";
 
@@ -7,3 +8,11 @@ export const loginSelector = () =>
     key: "login selector",
     get: () => axios({ method: "get", url: "/auth/check" }),
   });
+
+export const gallerySelector = (url?: string) => {
+  console.log(url);
+  return select<AxiosResponse<IGalleryDataResponse>>({
+    key: `gallery selector ${url}`,
+    get: () => axios({ method: "get", url }),
+  });
+};

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -9,10 +9,8 @@ export const loginSelector = () =>
     get: () => axios({ method: "get", url: "/auth/check" }),
   });
 
-export const gallerySelector = (url?: string) => {
-  console.log(url);
-  return select<AxiosResponse<IGalleryDataResponse>>({
+export const gallerySelector = (url?: string) =>
+  select<AxiosResponse<IGalleryDataResponse>>({
     key: `gallery selector ${url}`,
     get: () => axios({ method: "get", url }),
   });
-};

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -1,0 +1,9 @@
+import axios, { AxiosResponse } from "axios";
+import { ICheck } from "../hooks/useLoggedIn";
+import { select } from "./select";
+
+export const loginSelector = () =>
+  select<AxiosResponse<ICheck>>({
+    key: "login selector",
+    get: () => axios({ method: "get", url: "/auth/check" }),
+  });

--- a/client/src/store/test.store.ts
+++ b/client/src/store/test.store.ts
@@ -1,0 +1,23 @@
+import axios, { AxiosResponse } from "axios";
+import create from "zustand";
+import { select } from "./select";
+
+interface TestStore {
+  data: string;
+  getTest: () => string;
+  setData: (data: string) => void;
+}
+
+export const testSelector = () =>
+  select<AxiosResponse<string>>({
+    key: "test",
+    get: () => axios({ method: "get", url: `/test/gallery/12/123` }),
+  });
+
+const testStore = create<TestStore>((set) => ({
+  data: "no data",
+  getTest: () => testSelector().data,
+  setData: (newData) => set(() => ({ data: newData })),
+}));
+
+export default testStore;

--- a/client/src/store/user.store.ts
+++ b/client/src/store/user.store.ts
@@ -1,11 +1,14 @@
 import create from "zustand";
 import { User } from "../@types/common";
+import { ICheck } from "../hooks/useLoggedIn";
+import { loginSelector } from "./selectors";
 
 interface UserStore {
   isLoggedIn: boolean;
   isShared: boolean;
   isCreated: boolean;
   user: User;
+  getUser: () => ICheck;
   setUser: (user: User) => void;
   setShared: (shared: boolean) => void;
   setCreated: (created: boolean) => void;
@@ -17,6 +20,7 @@ const userStore = create<UserStore>((set) => ({
   isShared: false,
   isCreated: false,
   user: {},
+  getUser: () => loginSelector().data,
   setUser: (user) => set(() => ({ isLoggedIn: true, user })),
   setShared: (shared) => set(() => ({ isShared: shared })),
   setCreated: (created) => set(() => ({ isCreated: created })),


### PR DESCRIPTION
## Summary
기존의 resource, suspender 로직을 select, selector로 변경하고 errorboundary를 추가함으로써 GallerLoader 내부에서 관리되고 있던 에러처리 로직을 분리하였음

## Context
- Errorboundary 추가: Suspender와 비슷하게 throw된 에러를 catch함
- select, selector 로직 설계
- 기존에는 axios요청에만 활용 가능했던 resource, suspender 대비 모든 promise에 대한 비동기 처리 가능

아래와 같이 selector를 선언하여 사용, key값을 알맞게 바꾸어 주어야 refetching이 일어날 수 있음
```javascript
// store/selectors.ts
export const gallerySelector = (url?: string) =>
  select<AxiosResponse<IGalleryDataResponse>>({
    key: `gallery selector ${url}`,
    get: () => axios({ method: "get", url }),
  });

//store/gallery.store.ts
const galleryStore = create<GalleryStore>((set) => ({
  // ...
  getData: (url) => gallerySelector(url).data,
  // ...
}));
```
- 또한, 내부적으로 캐시를 사용하여 이미 보낸 요청에 대해 캐싱이 가능 따라서 strictmode로 인한 refetching이 일어나지 않으며 동일한 히스토리 요청을 다시 보내지 않을 수 있음

## Description
- 현재 캐시는 `const selectors = new Map<string, Selector<any>>();` 와 같이 간단한 구현체인데 이를 stale time을 두던지 하여 데이터가 오래되었다면 자동으로 refetching하도록 업그레이드 할 수 있음 ( 현재 서비스에서는 딱히 필요없을수도 있을듯 합니다. )
