### PR TITLE
feat: 스크린샷 기능 구현

### DIFF
--- a/client/src/GalleryPage/Gallery.tsx
+++ b/client/src/GalleryPage/Gallery.tsx
@@ -7,6 +7,7 @@ import Light from "./mapObjects/Light";
 import CollisionPlayerBody from "./components/CollisionPlayerBody";
 import MovementController from "./components/MovementController";
 import ViewRotateController from "./components/ViewRotateController";
+import ScreenshotCapturer from "../components/ScreenshotCapturer";
 import { BACKGROUND_COLORS } from "../@types/colors";
 import { THEME } from "../@types/gallery";
 import galleryStore from "../store/gallery.store";
@@ -22,7 +23,6 @@ export default function Gallery() {
       className="canvas-inner"
       camera={{ fov: 75, near: 0.1, far: 50, position: [0, 1.5, 5], rotation: [0.4, 0, 0] }}
       style={{ backgroundColor: (theme && BACKGROUND_COLORS[theme]) || THEME.DREAM }}
-      linear={false}
     >
       <color attach="background" args={[backgroundColor]} />
       <fog attach="fog" args={[backgroundColor, 30, 50]} />
@@ -33,6 +33,7 @@ export default function Gallery() {
         <ViewRotateController />
         <GalleryWorld data={data} />
       </Physics>
+      <ScreenshotCapturer />
     </Canvas>
   );
 }

--- a/client/src/MainPage/MainCanvas.tsx
+++ b/client/src/MainPage/MainCanvas.tsx
@@ -3,6 +3,7 @@ import { Canvas } from "@react-three/fiber";
 import { Box, Stats } from "@react-three/drei";
 
 import MainWorld from "./MainWorld";
+import ScreenshotCapturer from "../components/ScreenshotCapturer";
 
 import themeStore from "../store/theme.store";
 
@@ -24,6 +25,7 @@ export default function MainCanvas() {
       <MainWorld />
       <axesHelper />
       <Stats />
+      <ScreenshotCapturer />
     </Canvas>
   );
 }

--- a/client/src/components/Footer/index.tsx
+++ b/client/src/components/Footer/index.tsx
@@ -70,7 +70,13 @@ export default function Footer() {
         value={volume}
         onChange={(e) => setVolume(+e.target.value)}
       />
-      <button className="footer-element">
+      <button
+        className="footer-element"
+        onClick={(e) => {
+          document.dispatchEvent(new CustomEvent("save-screenshot"));
+          e.currentTarget.blur();
+        }}
+      >
         <img height={24} src={ScreenShotIcon} />
       </button>
       <button className="footer-element" onClick={onFullScreen}>

--- a/client/src/components/ScreenshotCapturer/index.tsx
+++ b/client/src/components/ScreenshotCapturer/index.tsx
@@ -1,0 +1,28 @@
+import { useRef, useEffect } from "react";
+import { useThree } from "@react-three/fiber";
+
+export default function ScreenshotCapturer() {
+  const { gl, scene, camera } = useThree();
+  const virtualLink = useRef(document.createElement("a"));
+
+  function saveBlob(blob: Blob | null) {
+    if (!virtualLink.current || blob === null) return;
+
+    const img = window.URL.createObjectURL(blob);
+    virtualLink.current.href = img;
+    virtualLink.current.download = "Monument Gallery";
+    virtualLink.current.click();
+    window.URL.revokeObjectURL(img);
+  }
+
+  useEffect(() => {
+    function saveScreenshot() {
+      gl.render(scene, camera);
+      gl.domElement.toBlob((blob) => saveBlob(blob));
+    }
+    document.addEventListener("save-screenshot", saveScreenshot);
+    return () => document.removeEventListener("save-screenshot", saveScreenshot);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summery
![image](https://user-images.githubusercontent.com/32293736/205699333-ff33481d-2ee8-4131-a746-1f5ba4f85e70.png)
스크린샷 기능을 구현했습니다.

## Context
스크린샷 기능이 존재하면 사용자가 가장 아름다운 순간을 포착할 수 있을 것이라는 생각에, 스크린샷 기능을 구현했습니다.
캔버스와 푸터는 굉장히 많이 떨어져 있기 때문에, 캔버스의 gl을 상위 컴포넌트로 올려야 했지만, 매우 번거로운 작업이며, 코드가 더러워질 것이라고 판단했습니다.
정욱님이 구현하신 커스텀 이벤트에서 영감을 받아서, screenshot 버튼은 스크린샷 이벤트를 전송하고, 스크린샷 컴포넌트가 스크린샷 이벤트를 구독해서 이벤트가 전송되면 정말로 스크린샷을 찍어서 렌더링하고, 캔버스 정보를 blob 데이터로 변경한 후 가상 a 태그를 클릭하는 방식으로 구현했습니다.
```javascript
function saveScreenshot() {
  gl.render(scene, camera);
  gl.domElement.toBlob((blob) => saveBlob(blob));
}
```
`gl.render`가 굳이 껴 있는 까닭은 `gl.render`가 존재하지 않는다면 기본적으로 브라우저는 렌더링 성능과 호환성 이유로 WebGL 캔버스에 오브젝트를 그린 뒤 **드로잉 버퍼를 지우기 때문**입니다. 이를 막기 위해 수동으로 렌더링하는 함수를 호출했습니다.
참고로 `gl.render(scene, camera)`와 같은 형태의 코드는 바닐라 three.js에서 장면을 렌더링하기 위해 사용됩니다.

## Description
- Footer 컴포넌트에 screenshot 이벤트 dispatch하는 코드 추가
- 스크린샷 컴포넌트 추가
- 메인 캔버스, 갤러리 캔버스에 스크린샷 컴포넌트 부착

## 레퍼런스
- 본인이 예전에 작성한 코드 (https://github.com/lybell-art/counting_the_star_words)
- https://webglfundamentals.org/webgl/lessons/ko/webgl-tips.html