### PR TITLE
Feat: search sparse

### DIFF
--- a/server/model/userModel.js
+++ b/server/model/userModel.js
@@ -69,9 +69,9 @@ export async function updateShareStateByUserID(userID, isShared, session) {
 export async function findLastGalleryIDByUserID(userID) {
   const history = await findHistoryByUserID(userID);
   const [result] = [...history].reduce(
-    ([rescentID, rescentDate], [galleryID, date]) => {
-      if (rescentDate < date) return [galleryID, date];
-      return [rescentID, rescentDate];
+    ([recentID, recentDate], [galleryID, date]) => {
+      if (recentDate < date) return [galleryID, date];
+      return [recentID, recentDate];
     },
     [null, 0],
   );

--- a/server/model/userModel.js
+++ b/server/model/userModel.js
@@ -83,7 +83,13 @@ export async function findAllUserNotShared(page, limit) {
   const yesterday = Date.now() - 1000 * 60 * 60 * 24;
   const users = await User.find({ isShared: false, lastShareModified: { $lte: yesterday } });
 }
-
+export async function findAllUserShared(limit) {
+  return await User.find({
+    isShared: true,
+  })
+    .sort({ lastModified: 1 })
+    .limit(limit);
+}
 export async function findAllUserRandom(randIdx, lastModified = 0, limit) {
   return await User.find({
     randIdx,

--- a/server/router/galleryRouter.js
+++ b/server/router/galleryRouter.js
@@ -6,7 +6,7 @@ import {
   createGalleryFromNotion,
   loadUserHistory,
   updateShareState,
-  searchGalleryRandom,
+  searchGalleryAll,
 } from "../service/galleryService.js";
 import { asyncHandler } from "../utils/utils.js";
 import { endConnectionSSE } from "../service/sseService.js";
@@ -18,7 +18,7 @@ router.get(
   "/gallery/all",
   asyncHandler(async (req, res) => {
     const cookieState = decodeBase64TOJSON(req.cookies.searchState);
-    const { searchState, gallerys } = await searchGalleryRandom(cookieState);
+    const { searchState, gallerys } = await searchGalleryAll(cookieState);
 
     res.cookie("searchState", encodeBase64FromJSON(searchState));
     res.status(200).json(gallerys);

--- a/server/router/testRouter.js
+++ b/server/router/testRouter.js
@@ -8,7 +8,7 @@ import Gallery from "../schema/gallerySchema.js";
 import User from "../schema/userSchema.js";
 import { getImagePixelsFromPages } from "../service/imageProcessService.js";
 import { createConnectionSSE, endConnectionSSE, writeMessageSSE } from "../service/sseService.js";
-import { deleteUserHistory, saveGallery, searchGalleryRandom } from "../service/galleryService.js";
+import { deleteUserHistory, saveGallery, searchGalleryAll } from "../service/galleryService.js";
 import { asyncHandler } from "../utils/utils.js";
 import userDummyData from "../model/userDummyData.js";
 import galleryDummyData from "../model/galleryDummyData.js";
@@ -42,7 +42,7 @@ router.get(
   "/getDataIdx",
   asyncHandler(async (req, res) => {
     const cookieState = req.cookies.searchState ? decodeBase64(makeBase64URLToBase64(req.cookies.searchState)) : null;
-    const { searchState, gallerys } = await searchGalleryRandom(JSON.parse(cookieState ?? "{}"));
+    const { searchState, gallerys } = await searchGalleryAll(JSON.parse(cookieState ?? "{}"));
     console.log(gallerys);
     res.cookie("searchState", makeBase64ToBase64URL(makeJsonToBase64(searchState)));
     res.send("good");

--- a/server/service/galleryService.js
+++ b/server/service/galleryService.js
@@ -227,13 +227,13 @@ export async function searchGalleryAll(requestSearchState) {
 
   // console.log(gallerys);
   if (gallerys.length === 0) {
-    const latestUsers = await findAllUserShared(15);
-    const latestGallerys = await Promise.all(
-      latestUsers.map(async (user) => {
+    const recentUsers = await findAllUserShared(15);
+    const recentGallerys = await Promise.all(
+      recentUsers.map(async (user) => {
         const [lastGalleryID] = [...user.history].reduce(
-          ([rescentID, rescentDate], [galleryID, date]) => {
-            if (rescentDate < date) return [galleryID, date];
-            return [rescentID, rescentDate];
+          ([recentID, recentDate], [galleryID, date]) => {
+            if (recentDate < date) return [galleryID, date];
+            return [recentID, recentDate];
           },
           [null, 0],
         );
@@ -248,7 +248,7 @@ export async function searchGalleryAll(requestSearchState) {
       }),
     );
 
-    return { searchState, gallerys: latestGallerys };
+    return { searchState, gallerys: recentGallerys };
   }
   return { searchState, gallerys };
 }
@@ -262,9 +262,9 @@ async function searchGalleryRandom(searchState, nowIdx) {
   const gallerys = await Promise.all(
     users.map(async (user) => {
       const [lastGalleryID] = [...user.history].reduce(
-        ([rescentID, rescentDate], [galleryID, date]) => {
-          if (rescentDate < date) return [galleryID, date];
-          return [rescentID, rescentDate];
+        ([recentID, recentDate], [galleryID, date]) => {
+          if (recentDate < date) return [galleryID, date];
+          return [recentID, recentDate];
         },
         [null, 0],
       );

--- a/server/service/galleryService.js
+++ b/server/service/galleryService.js
@@ -205,60 +205,86 @@ function getRandomDate() {
   return getRandomInt(0, Date.now());
 }
 function checkValidIndex(searchState, idx) {
-  if (!(idx in searchState)) return false;
-  const { start, last, curved } = searchState[idx];
-  return start <= last && curved;
+  if (!(idx in searchState)) return true;
+  return searchState[idx].valid;
 }
 function getRandomIndex(searchState) {
   let res = getRandomInt(0, 5);
   const start = res;
-  if (checkValidIndex(searchState, res)) res = (res + 1) % 5;
+  if (!checkValidIndex(searchState, res)) res = (res + 1) % 5;
 
-  while (checkValidIndex(searchState, res) && start !== res) {
+  while (!checkValidIndex(searchState, res) && start !== res) {
     res = (res + 1) % 5;
   }
-  if (checkValidIndex(searchState, res) && start === res) console.log("오링"); //데이터 다 씀!
+  if (!checkValidIndex(searchState, res) && start === res) {
+    console.log("오링", res); //데이터 다 씀!
+    return -1;
+  }
   return res;
 }
 export async function searchGalleryAll(requestSearchState) {
-  // console.log(searchState);
+  if (!requestSearchState) requestSearchState = initSearchState();
   const nowIdx = getRandomIndex(requestSearchState);
+  if (nowIdx === -1) return { searchState: requestSearchState, gallerys: [] };
+  // console.log(nowIdx);
+  // let searchState = requestSearchState;
+  // let gallerys = [];
+  // let searchCnt = 0;
+
+  // while (gallerys.length < 15 && searchCnt++ < 10 && nowIdx !== -1) {
+  //   const searchData = await searchGalleryRandom(searchState, nowIdx);
+  //   searchState = searchData.searchState;
+  //   gallerys = [...gallerys, ...searchData.gallerys];
+  //   nowIdx = getRandomIndex(requestSearchState);
+  // }
   const { searchState, gallerys } = await searchGalleryRandom(requestSearchState, nowIdx);
 
   // console.log(gallerys);
   if (gallerys.length === 0) {
-    const recentUsers = await findAllUserShared(15);
-    const recentGallerys = await Promise.all(
-      recentUsers.map(async (user) => {
-        const [lastGalleryID] = [...user.history].reduce(
-          ([recentID, recentDate], [galleryID, date]) => {
-            if (recentDate < date) return [galleryID, date];
-            return [recentID, recentDate];
-          },
-          [null, 0],
-        );
-        //map에 null들어가면 어케 되려나
-        const gallery = await findGalleryByID(lastGalleryID);
-
-        return {
-          userName: user.userName,
-          keywords: gallery.totalKeywords.slice(0, 3).map((keywordData) => keywordData.keyword),
-          galleryURL: `/gallery/${user.userID}/${lastGalleryID}`,
-        };
-      }),
-    );
-
+    const recentGallerys = await searchGalleryRecent(15);
+    if (recentGallerys.length < 15) {
+      Object.keys(searchState).forEach((key) => (searchState[key].valid = false));
+    }
     return { searchState, gallerys: recentGallerys };
   }
   return { searchState, gallerys };
 }
 
-async function searchGalleryRandom(searchState, nowIdx) {
+function initSearchState() {
   const randomDate = getRandomDate();
-  if (!(nowIdx in searchState)) searchState[nowIdx] = { start: randomDate, last: randomDate, curved: false };
+  const randIdxs = [0, 1, 2, 3, 4];
+  return randIdxs.reduce((acc, cur) => {
+    acc[cur] = { start: randomDate, last: randomDate, curved: false, valid: true };
+    return acc;
+  }, {});
+}
 
+async function searchGalleryRecent(limit) {
+  const recentUsers = await findAllUserShared(15);
+  return await Promise.all(
+    recentUsers.map(async (user) => {
+      const [lastGalleryID] = [...user.history].reduce(
+        ([recentID, recentDate], [galleryID, date]) => {
+          if (recentDate < date) return [galleryID, date];
+          return [recentID, recentDate];
+        },
+        [null, 0],
+      );
+      //map에 null들어가면 어케 되려나
+      const gallery = await findGalleryByID(lastGalleryID);
+
+      return {
+        userName: user.userName,
+        keywords: gallery.totalKeywords.slice(0, 3).map((keywordData) => keywordData.keyword),
+        galleryURL: `/gallery/${user.userID}/${lastGalleryID}`,
+      };
+    }),
+  );
+}
+
+async function searchGalleryRandom(searchState, nowIdx) {
   const users = await findAllUserRandom(nowIdx, searchState[nowIdx].last, 15);
-  // console.log(users);
+  console.log(users);
   const gallerys = await Promise.all(
     users.map(async (user) => {
       const [lastGalleryID] = [...user.history].reduce(
@@ -280,11 +306,20 @@ async function searchGalleryRandom(searchState, nowIdx) {
   );
 
   if (users.length > 0) searchState[nowIdx].last = Date.parse(users.at(-1).lastModified);
-  if (users.length < 15) {
+
+  const { start, last, curved } = searchState[nowIdx];
+
+  if (users.length < 15 && !curved) {
+    //끝 도달
+    console.log("curved", nowIdx);
     searchState[nowIdx].curved = true;
     searchState[nowIdx].last = 0;
+  } else if (curved && (users.length < 15 || last >= start)) {
+    //전체 데이터 크기가 작은 경우 or 한바퀴 돈 경우
+    searchState[nowIdx].valid = false;
+    // console.log(searchState);
   }
-
+  // console.log(searchState);
   return { searchState, gallerys };
 }
 //search

--- a/server/utils/base64.js
+++ b/server/utils/base64.js
@@ -1,5 +1,5 @@
 export function decodeBase64TOJSON(base64URL) {
-  if (!base64URL) return {};
+  if (!base64URL) return null;
   return JSON.parse(Buffer.from(makeBase64URLToBase64(base64URL), "base64").toString("utf8") ?? "{}");
 }
 


### PR DESCRIPTION
# Summary
데이터가 적은 경우의 로직을 더 다듬음
# Context
데이터가 적어 각 randIdx에 데이터가 없거나, 읽어오는 시작점이 끝에 위치해 0개의 데이터를 불러오는 경우를 제거하기 위함 
# Description
- 이전에 호출했던 것들은 다시 호출하지 않도록 로직 변경 ( 더이상 불러 올 게 없으면 그냥 빈 배열 반환 )
- 데이터가 적은 경우도 한 번만 호출하도록 변경
  - 이때, 쿼리의 수를 줄이기 위해 부득이하게 최신 순으로 탐색함
    - while문을 돌리는 건 좀 그래 보였습니다...
  - 정상적인 경우엔 여전히 랜덤 탐색
- 의견 주시면 적극 반영해보겠습니다