### PR TITLE
Refactor: Get-Notion

### DIFF
--- a/server/service/dataProcessService.js
+++ b/server/service/dataProcessService.js
@@ -45,19 +45,19 @@ function attachAllDataForDB(rawContent, notionKeyword, theme, positionData) {
         keywords: getTop30Keywords(notionKeyword.ppPages[page.id].keywords),
         title: rawContent[page.id].title ? rawContent[page.id].title : "-",
         subtitle: [
-          ...notionKeyword.ppPages[page.id].h1_keywords.map((keyword) => {
+          ...rawContent[page.id].h1.map((keyword) => {
             return {
               hType: "h1",
               text: keyword,
             };
           }),
-          ...notionKeyword.ppPages[page.id].h2_keywords.map((keyword) => {
+          ...rawContent[page.id].h2.map((keyword) => {
             return {
               hType: "h2",
               text: keyword,
             };
           }),
-          ...notionKeyword.ppPages[page.id].h3_keywords.map((keyword) => {
+          ...rawContent[page.id].h3.map((keyword) => {
             return {
               hType: "h3",
               text: keyword,

--- a/server/service/galleryService.js
+++ b/server/service/galleryService.js
@@ -164,7 +164,6 @@ export async function createGalleryFromNotion(notionAccessToken, period, theme, 
 
   writeMessageSSE(JSON.stringify({ kind: "노션 데이터 불러오는 중...", progress: 10, data: {} }), res);
   let pageContents = await getRoot(notion, limitTime);
-  console.log(pageContents);
   let deepth = 0;
 
   while (Object.keys(pageContents).length <= 85 && deepth++ < 2) {
@@ -181,6 +180,7 @@ export async function createGalleryFromNotion(notionAccessToken, period, theme, 
     // console.log(childPages);
     pageContents = { ...pageContents, ...childPages };
   }
+  console.log(pageContents);
   pageContents = Object.keys(pageContents)
     .splice(0, 85)
     .map((pageID) => {

--- a/server/service/galleryService.js
+++ b/server/service/galleryService.js
@@ -159,29 +159,31 @@ export async function createGalleryFromNotion(notionAccessToken, period, theme, 
   createConnectionSSE(res);
   const limitTime = getLimitTime(period);
   const notion = new Client({ auth: notionAccessToken });
-
+  const nowTime = Date.now();
   writeMessageSSE(JSON.stringify({ kind: "노션 데이터 불러오는 중...", progress: 5, data: {} }), res);
 
-  writeMessageSSE(JSON.stringify({ kind: "루트 페이지 불러오는 중...", progress: 10, data: {} }), res);
+  writeMessageSSE(JSON.stringify({ kind: "노션 데이터 불러오는 중...", progress: 10, data: {} }), res);
   let pageContents = await getRoot(notion, limitTime);
-  console.log(pageContents);
+  // console.log(pageContents);
   let deepth = 0;
 
   while (Object.keys(pageContents).length <= 85 && deepth++ < 2) {
     // console.log(pageContents);
     writeMessageSSE(
       JSON.stringify({
-        kind: `${deepth}단계의 페이지 불러오는 중...`,
+        kind: `노션 데이터 불러오는 중...`,
         progress: 20 + 10 * deepth <= 55 ? 20 + 10 * deepth : 55,
         data: {},
       }),
       res,
     );
     const childPages = await getChildPages(notion, pageContents, limitTime);
-    console.log(childPages);
+    // console.log(childPages);
     pageContents = [...pageContents, ...childPages];
   }
+  pageContents = pageContents.splice(0, 85);
 
+  console.log("notionData 처리 시간", Date.now() - nowTime);
   writeMessageSSE(JSON.stringify({ kind: "노션 데이터 불러오기 완료", progress: 60, data: {} }), res);
 
   writeMessageSSE(JSON.stringify({ kind: "이미지 가공 중...", progress: 65, data: {} }), res);

--- a/server/service/galleryService.js
+++ b/server/service/galleryService.js
@@ -164,7 +164,7 @@ export async function createGalleryFromNotion(notionAccessToken, period, theme, 
 
   writeMessageSSE(JSON.stringify({ kind: "노션 데이터 불러오는 중...", progress: 10, data: {} }), res);
   let pageContents = await getRoot(notion, limitTime);
-  // console.log(pageContents);
+  console.log(pageContents);
   let deepth = 0;
 
   while (Object.keys(pageContents).length <= 85 && deepth++ < 2) {
@@ -179,9 +179,13 @@ export async function createGalleryFromNotion(notionAccessToken, period, theme, 
     );
     const childPages = await getChildPages(notion, pageContents, limitTime);
     // console.log(childPages);
-    pageContents = [...pageContents, ...childPages];
+    pageContents = { ...pageContents, ...childPages };
   }
-  pageContents = pageContents.splice(0, 85);
+  pageContents = Object.keys(pageContents)
+    .splice(0, 85)
+    .map((pageID) => {
+      return pageContents[pageID];
+    });
 
   console.log("notionData 처리 시간", Date.now() - nowTime);
   writeMessageSSE(JSON.stringify({ kind: "노션 데이터 불러오기 완료", progress: 60, data: {} }), res);

--- a/server/service/getNotionContentService.js
+++ b/server/service/getNotionContentService.js
@@ -403,17 +403,21 @@ async function getDataFromColumnList(notion, columnListId) {
     childDatabase: [],
   };
 
-  for (let i = 0; i < columns.results.length; i++) {
-    const columnData = await notion.blocks.children.list({
-      block_id: columns.results[i].id,
-      page_size: 50,
-    });
-    const processedData = processPageData(notion, columnData.results);
+  const columnDatas = await Promise.all(
+    columns.results.map(async (column) => {
+      const columnData = await notion.blocks.children.list({
+        block_id: column.id,
+        page_size: 50,
+      });
+      return processPageData(columnData.results);
+    }),
+  );
 
-    Object.keys(processedData).forEach((key) => {
-      res[key] = [...res[key], ...processedData[key]];
+  columnDatas.forEach((columnData) => {
+    Object.keys(columnData).forEach((key) => {
+      res[key] = [...res[key], ...columnData[key]];
     });
-  }
+  });
 
   return res;
 }

--- a/server/service/getNotionContentService.js
+++ b/server/service/getNotionContentService.js
@@ -46,7 +46,12 @@ export function sumObject(obj1, obj2) {
     paragraph: obj2?.paragraph,
   };
 }
-
+function changeArrayToObject(ary) {
+  return ary.reduce((acc, cur) => {
+    if (cur?.id) acc[cur.id] = cur;
+    return acc;
+  }, {});
+}
 async function getRootPages(notion, limitTime, type) {
   const pageResponse = await notion.search({
     filter: { property: "object", value: type },

--- a/server/service/getNotionContentService.js
+++ b/server/service/getNotionContentService.js
@@ -95,8 +95,6 @@ function sumArray(ary) {
 }
 
 export async function getChildPages(notion, pageContents, limitTime) {
-  // if (cursor >= pageID.length || pageID.length > 85) return pageContents;
-
   return changeArrayToObject(
     sumArray(
       await Promise.all(
@@ -117,18 +115,6 @@ export async function getChildPages(notion, pageContents, limitTime) {
       ),
     ),
   );
-
-  // const cursorID = pageID[cursor];
-  // for (let i = 0; i < pageContents[cursorID].childPage.length && pageID.length <= 85; i++) {
-  //   const nowPage = pageContents[cursorID].childPage[i];
-  //   if (nowPage.id in pageContents || nowPage.lastEditedTime > limitTime) continue;
-  //   pageID.push(nowPage.id);
-  //   if (nowPage.type === "page") {
-  //     pageContents[nowPage.id] = sumObject(nowPage, await getDataFromPage(notion, nowPage.id));
-  //   } else {
-  //     pageContents[nowPage.id] = sumObject(nowPage, await getDataFromDatabase(notion, nowPage.id));
-  //   }
-  // }
 }
 async function getPages(notion, limitTime) {
   //deprecated

--- a/server/service/getNotionContentService.js
+++ b/server/service/getNotionContentService.js
@@ -74,13 +74,9 @@ async function getRootPages(notion, limitTime, type) {
 }
 
 export async function getRoot(notion, limitTime) {
-  const pageContents = {
-    ...(await getRootPages(notion, limitTime, "page")),
-    ...(await getRootPages(notion, limitTime, "database")),
-  };
-  const pageID = Object.keys(pageContents);
+  return [...(await getRootPages(notion, limitTime, "page")), ...(await getRootPages(notion, limitTime, "database"))];
+}
 
-  return { pageContents, pageID };
 }
 
 export async function getChildPages(notion, pageContents, pageID, cursor, limitTime) {

--- a/server/service/getNotionContentService.js
+++ b/server/service/getNotionContentService.js
@@ -191,7 +191,7 @@ export async function getDataFromPage(notion, pageId) {
       const innerText = getTextFromTextObject(childDatabase?.title);
       res.childPage.push({
         type: "database",
-        id: res.childDatabase[i],
+        id: childDatabase.id,
         title: innerText?.length > 0 ? innerText[0] : "-",
         createdTime: childDatabase.created_time,
         lastEditedTime: childDatabase.last_edited_time,

--- a/server/service/getNotionContentService.js
+++ b/server/service/getNotionContentService.js
@@ -212,7 +212,7 @@ export async function getDataFromPage(notion, pageId) {
   return res;
 }
 
-function processPageData(notion, data) {
+function processPageData(data) {
   // 다른 함수들과 res의 형식이 강결합돼있으므로 여기 수정 시 모두 수정해야함
   const res = {
     position: [],


### PR DESCRIPTION
# Summary
기존 오래 걸리던 로직 단축, 결과물에 제목이 키워드로 나오던 것 raw하게 나오는 걸로 변경
# Description
### 기존 **2분 이상**걸리던 로직 **40초**가량으로 감소
- 기존 로직
  - 루트페이지부터 자식페이지까지 순서를 지키며 1개씩 받아오기 -> Promise.all() 적용하기가 힘듦
  - 85개가 되면 멈춤
    - 메모리 부분에서 유리함
- 새로운 로직
  - deepth단위로 순서 상관없이 불러오기 -> Promise.all() 적용 가능
  - 85개를 넘든지 말던지 한번에 불러온 후, 이후 85개에서 자름
    - 메모리를 조금 더 차지함, 대신 속도가 훨씬 빠름
  - 전체 개수를 제한하니 키워드 불러오는게 빨라져서 FastAPI쪽은 따로 리팩토링 하지 않았음
- 로딩 창에 어느 페이지를 처리중인지 알려주는 기능 제거
  - 로딩이 전체적으로 빨라져서 deepth에 따라 진행도만 바꿔줬습니다
  
<img width="955" alt="image" src="https://user-images.githubusercontent.com/46295027/206386314-2b1beb5e-a7b2-4fd8-8855-11a5d6541169.png">
<img width="975" alt="image" src="https://user-images.githubusercontent.com/46295027/206386375-1df12a76-81b1-41a0-bc64-cb12ebba41a7.png">


### 이미지 처리 단계에서의 오류
PIL이 svg형식을 지원하지 않는다고 합니다.
https://stackoverflow.com/questions/15130670/pil-and-vectorbased-graphics

그냥 무시를 할 지, svg를 png로 변환해주는 라이브러리를 사용할 지 고민중