### PR TITLE
fix: 노션 데이터베이스 페이지의 하위 페이지를 처리할 때 자신의 url을 누락하는 버그 수정

### DIFF
--- a/client/src/layouts/FloatLayout/style.scss
+++ b/client/src/layouts/FloatLayout/style.scss
@@ -8,7 +8,7 @@
     position: relative;
     width: 100vw;
     height: 100vh;
-    * {
+    *:not(.header) {
       pointer-events: auto;
     }
   }

--- a/server/service/getNotionContentService.js
+++ b/server/service/getNotionContentService.js
@@ -31,6 +31,9 @@ function getPageBasic(result, type) {
 }
 
 export function sumObject(obj1, obj2) {
+  const links = [...obj2.links];
+  if (obj1.myUrl) links.push({ href: obj1.myUrl, favicon: "" });
+
   //obj1이 기준임
   return {
     id: obj1?.id,
@@ -44,7 +47,7 @@ export function sumObject(obj1, obj2) {
     h1: obj2?.h1,
     h2: obj2?.h2,
     h3: obj2?.h3,
-    links: [...obj2.links, { href: obj1.myUrl, favicon: "" }],
+    links: links,
     image: obj2?.image,
     paragraph: obj2?.paragraph,
   };
@@ -316,7 +319,7 @@ function processPageData(data) {
         // console.log("임베드링크: ", val.embed);
         if (val.embed?.url) {
           res.links.push({
-            href: val.embed.link,
+            href: val.embed.url,
             favicon: "",
           });
         }
@@ -378,6 +381,7 @@ export async function getDataFromDatabase(notion, databaseId) {
       title: getTitleFromProperties(data.properties),
       createdTime: data.created_time,
       lastEditedTime: data.last_edited_time,
+      myUrl: data.url,
     });
   });
 


### PR DESCRIPTION
## Summery
생성된 갤러리 공간에 일부 공간의 링크가 누락되는 버그를 수정했습니다.
## Context
노션 데이터베이스 페이지의 하위 페이지의 url이 유실되는 버그였으며, 해당 부분은 `getDataFromDatabase` 함수에서 myUrl 프로퍼티가 누락되어서 발생한 버그로 판명되었습니다. 해당 부분을 수정했습니다.
## Description
- 노션 데이터베이스 페이지의 하위 페이지를 처리할 때 자신의 url을 누락하는 버그 수정
- 헤더의 빈 공간에 캔버스를 인터랙션할 수 없는 버그 수정