### PR TITLE
fix: mac에서 blur 이벤트가 동작하지 않는 경우 대응

### DIFF
--- a/client/src/hooks/useKeyMovement.ts
+++ b/client/src/hooks/useKeyMovement.ts
@@ -54,27 +54,35 @@ export function useKeyMovement() {
   useEffect(() => {
     function keyDown(e: KeyboardEvent) {
       const movementKey = mapMovementKey(e.code);
+      if (e.metaKey === true && e.shiftKey === true) {
+        allRelease();
+        return;
+      }
       if (movementKey === null) return;
       if (getKeyState(movementKey) === true) return;
       controlKeyState({ type: "keydown", code: movementKey });
     }
     function keyUp(e: KeyboardEvent) {
+      console.log("keyUp called");
       const movementKey = mapMovementKey(e.code);
       if (movementKey === null) return;
       controlKeyState({ type: "keyup", code: movementKey });
     }
     function allRelease() {
       controlKeyState({ type: "allKeyUp", code: "" });
+      console.log("All released");
     }
 
     document.addEventListener("keydown", keyDown);
     document.addEventListener("keyup", keyUp);
     window.addEventListener("blur", allRelease);
+    window.addEventListener("fullscreenchange", allRelease);
 
     return () => {
       document.removeEventListener("keydown", keyDown);
       document.removeEventListener("keyup", keyUp);
       window.removeEventListener("blur", allRelease);
+      window.removeEventListener("fullscreenchange", allRelease);
     };
   }, [keyState]);
 

--- a/client/src/store/gallery.store.ts
+++ b/client/src/store/gallery.store.ts
@@ -15,6 +15,7 @@ const galleryStore = create<GalleryStore>((set) => ({
   data: {
     nodes: [[]],
     pages: [],
+    userName: "",
     totalKeywords: {},
     groupKeywords: [],
     theme: THEME.DREAM,


### PR DESCRIPTION
맥에서 스크린샷을 찍을때 커맨드 + 컨트롤 + 시프트 + 3,4 키를 이용하는데, 이때 blur 이벤트가 동작하지 않는 문제가 있었습니다.
따라서 강제로 커맨드,컨트롤을 같이 입력했는지를 검사해서 allRelease를 해주는 식으로 해결하였습니다