### PR TITLE
hotfix: 제목이 없을 때 자연어 처리가 불가능한 버그 수정

### DIFF
--- a/client/src/@types/gallery.ts
+++ b/client/src/@types/gallery.ts
@@ -37,6 +37,7 @@ export interface IGalleryMapData {
   pages: IGalleryPageData[];
   nodes: number[][];
   views?: number;
+  modifiedDate?: number;
 }
 
 export interface IGalleryDataResponse {

--- a/client/src/GalleryPage/GalleryWorld.tsx
+++ b/client/src/GalleryPage/GalleryWorld.tsx
@@ -10,7 +10,7 @@ interface GalleryWorldProps {
 }
 
 export default function GalleryWorld({ data }: GalleryWorldProps) {
-  const { totalKeywords, groupKeywords, pages, nodes } = data;
+  const { totalKeywords, groupKeywords, pages, nodes, modifiedDate } = data;
   const pageIslandPosition = pages.map(({ position }: IGalleryPageData): Vector3Arr => [position[0], 0, position[1]]);
   const getIslandPosition = (i: number): Vector3Arr => {
     if (i === -1) return [0, 0, 0];
@@ -23,7 +23,7 @@ export default function GalleryWorld({ data }: GalleryWorldProps) {
     <>
       <GalleryCenterIsland keywords={totalKeywords} groupKeywords={groupKeywords} />
       {pages.map((pageData: IGalleryPageData, i: number) => {
-        const id = `${pageData.title}__${i}`;
+        const id = `${modifiedDate}__${pageData.title}__${i}`;
         return <GalleryPageIsland {...pageData} key={id} />;
       })}
       {nodes.map((nodeData: number[]) => {

--- a/client/src/store/gallery.store.ts
+++ b/client/src/store/gallery.store.ts
@@ -20,11 +20,12 @@ const galleryStore = create<GalleryStore>((set) => ({
     totalKeywords: {},
     groupKeywords: [],
     theme: THEME.DREAM,
+    modifiedDate: Date.now(),
   },
   userId: null,
   theme: THEME.DREAM,
   getData: (url) => gallerySelector(url).data,
-  setData: (data, userId) => set({ data, userId, theme: data.theme }),
+  setData: (data, userId) => set({ data: { ...data, modifiedDate: Date.now() }, userId, theme: data.theme }),
   setTheme: (theme) => set({ theme }),
 }));
 

--- a/server/service/dataProcessService.js
+++ b/server/service/dataProcessService.js
@@ -86,7 +86,7 @@ async function getKeywordFromFastAPI(rawContent) {
   try {
     const fastapiEndpoint = process.env.FASTAPI_ENDPOINT;
     const fastapiData = getFastAPIFormData(rawContent);
-    // console.log(fastapiData);
+    // console.log(JSON.stringify(fastapiData));
     // console.log(fastapiData.pages);
     const fastapiResponse = await axios.post(fastapiEndpoint + "/preprocess/text", fastapiData);
     return fastapiResponse.data;
@@ -135,7 +135,7 @@ function getFastAPIFormData(rawContent) {
     (acc, cur) => {
       // console.log(cur);
       acc.pages[cur] = {
-        title: rawContent[cur].title,
+        title: rawContent[cur].title ?? "",
         h1: rawContent[cur].h1,
         h2: rawContent[cur].h2,
         h3: rawContent[cur].h3,


### PR DESCRIPTION
## Summery
- 제목이 없을 때 자연어 처리가 불가능한 버그를 수정했습니다.
- 동기화 후 간헐적으로 섬이 엇나가는 버그를... 해치웠나?

## Context
```javascript
function getFastAPIFormData(rawContent) {
  //data를 fastapi 서버로 보내기 용이한 형태로 가공
  return Object.keys(rawContent).reduce(
    (acc, cur) => {
      // console.log(cur);
      acc.pages[cur] = {
        title: rawContent[cur].title ?? "",
        h1: rawContent[cur].h1,
        h2: rawContent[cur].h2,
        h3: rawContent[cur].h3,
        paragraph: rawContent[cur].paragraph,
      };
      return acc;
    },
    { pages: {} },
  );
}
```
문자 데이터를 fastapi 서버로 보내는 과정에서 제목이 없는 문서는 title에 undefined가 들어갑니다. python은 title에 string 자료형이 올 것이라고 기대하지만, 실제로 받은 것은 null이므로 타입 오류가 발생하게 됩니다. 해당 부분은 null 변환 연산자로 null일 때 빈 문자열을 대신 집어넣는 것으로 해결했습니다.

```typescript
{pages.map((pageData: IGalleryPageData, i: number) => {
  const id = `${modifiedDate}__${pageData.title}__${i}`;
  return <GalleryPageIsland {...pageData} key={id} />;
})}
```
갤러리 페이지 섬을 렌더링할 때 pageData.title_i 형식으로 렌더링을 진행하는데, pageData.title과  i가 같고 나머지 데이터가 바뀌면 렌더링이 되지 않을 가능성이 존재합니다. data를 불러올 때 현재 시각을 같이 저장해서 해결을 하고 싶었습니다.

## Description
**해치웠나?**